### PR TITLE
🔧 [chore] : Storybook 배포 워크플로우 추가 및 .gitignore에 Vercel 관련 항목 추가

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -1,0 +1,43 @@
+name: Deploy Storybook
+
+# Main 브랜치에 packages/ui 폴더 내 변경 사항이 push될 때만 실행
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'packages/ui/**' 
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      # 1️⃣ 레포 체크아웃
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+
+      # 2️⃣ Node.js 설정
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+          cache: 'pnpm' # pnpm 캐싱 설정
+
+      # 3️⃣ 의존성 설치
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      # 4️⃣ Storybook 빌드 (@ui 패키지만)
+      - name: Build Storybook
+        run: pnpm --filter @ui build-storybook
+
+      # 5️⃣ Vercel 배포 (안정적인 최신 Action 사용)
+      - name: Deploy to Vercel
+        uses: amondnet/vercel-action@v25 # 현재 가장 많이 사용되는 안정적인 버전으로 변경
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN_UI }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID_UI }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID_UI }}
+          working-directory: packages/ui
+          vercel-args: '--prod' 

--- a/packages/ui/.gitignore
+++ b/packages/ui/.gitignore
@@ -73,3 +73,4 @@ next-env.d.ts
 
 # ESLint cache
 .eslintcache
+.vercel


### PR DESCRIPTION
## 📌 변경 사항 개요

디자인 시스템 패키지(`packages/ui`)의 Storybook 빌드 결과물을 `main` 브랜치에 Merge 시 **Vercel에 자동으로 배포**하도록 GitHub Actions 워크플로우를 추가합니다.

이는 웹 앱(`apps/web`) 배포와 **완전히 분리된 독립적인 디자인 시스템 문서 사이트**를 구축하는 인프라 초기 설정입니다.

## 📝 상세 내용

### 1. Storybook 자동 배포 워크플로우 추가

* 파일: `.github/workflows/deploy-storybook.yml`
* **트리거**: `main` 브랜치에 `packages/ui/**` 경로의 파일이 Push 될 때만 실행됩니다.
* **작업**: `pnpm --filter @ui build-storybook` 명령어로 Storybook을 빌드하고 `amondnet/vercel-action@v25`를 이용해 Vercel에 배포합니다.
* **배포 URL**: 배포가 성공하면, 디자인 시스템의 공식 문서 URL이 Vercel을 통해 생성됩니다.

### 2. Vercel Secrets 분리 및 정의

기존 웹 앱 배포 Secret과의 충돌을 방지하고 명확성을 위해 Storybook 전용 Secret 이름을 정의하고 사용했습니다.

* `VERCEL_TOKEN_UI`
* `VERCEL_ORG_ID_UI`
* `VERCEL_PROJECT_ID_UI`

### 3. packages/ui 설정 준비

* Vercel 프로젝트 설정 시 **working-directory**를 `packages/ui`로 지정하여 해당 패키지만 배포되도록 설정했습니다.

## 🔗 관련 이슈

Resolves: #4 (디자인 시스템 문서화 구축 목표)

## 🖼️ 스크린샷(선택사항)


## 💡 참고 사항

배포 테스트는 추후에 완료된 후에 진행하겠습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 메인 브랜치에 UI 변경이 포함될 때 스토리북을 자동으로 빌드·배포하는 워크플로우를 추가했습니다.
  * 필요할 때만 배포가 트리거되어 불필요한 실행을 줄이고, 변경 사항이 신속히 미리보기 환경에 반영됩니다.
  * 설치/빌드 캐시 최적화로 배포 속도와 안정성을 개선했습니다.
  * 이제 수동 절차 없이 최신 문서화된 UI 컴포넌트를 바로 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->