### PR TITLE
✨ feat :  카테고리 (장소) 뱃지 구현

### DIFF
--- a/packages/ui/src/components/Badge/CategoryBadge.stories.tsx
+++ b/packages/ui/src/components/Badge/CategoryBadge.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { categoryLabels } from '../../tokens/categoryLabels';
+import { iconPaths } from '../../tokens/iconPath';
+import { CategoryBadge } from './CategoryBadge';
+
+const meta: Meta<typeof CategoryBadge> = {
+  title: 'Components/Badge/CategoryBadge',
+  component: CategoryBadge,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: '카테고리별 뱃지를 보기 좋게 정렬한 전체 미리보기입니다.',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof CategoryBadge>;
+
+/* 🎨 전체 카테고리 보기 */
+export const AllCategories: Story = {
+  render: () => (
+    <div className='flex min-h-screen w-full justify-center bg-[var(--color-background)] py-16'>
+      <div className='grid grid-cols-2 gap-6 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6'>
+        {(
+          Object.keys(iconPaths.category) as Array<
+            keyof typeof iconPaths.category
+          >
+        ).map((key) => (
+          <div key={key} className='flex justify-center'>
+            <CategoryBadge
+              category={key}
+              icon={key}
+              label={categoryLabels[key]}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  ),
+};
+
+/* ✨ 단일 예시 */
+export const Cafe: Story = {
+  args: {
+    category: 'cafe',
+    label: '카페',
+    icon: 'cafe',
+  },
+};
+
+export const Restaurant: Story = {
+  args: {
+    category: 'restaurant',
+    label: '식당',
+    icon: 'restaurant',
+  },
+};

--- a/packages/ui/src/components/Badge/CategoryBadge.stories.tsx
+++ b/packages/ui/src/components/Badge/CategoryBadge.stories.tsx
@@ -31,11 +31,7 @@ export const AllCategories: Story = {
           >
         ).map((key) => (
           <div key={key} className='flex justify-center'>
-            <CategoryBadge
-              category={key}
-              icon={key}
-              label={categoryLabels[key]}
-            />
+            <CategoryBadge category={key} label={categoryLabels[key]} />
           </div>
         ))}
       </div>
@@ -48,7 +44,6 @@ export const Cafe: Story = {
   args: {
     category: 'cafe',
     label: '카페',
-    icon: 'cafe',
   },
 };
 
@@ -56,6 +51,5 @@ export const Restaurant: Story = {
   args: {
     category: 'restaurant',
     label: '식당',
-    icon: 'restaurant',
   },
 };

--- a/packages/ui/src/components/Badge/CategoryBadge.tsx
+++ b/packages/ui/src/components/Badge/CategoryBadge.tsx
@@ -5,14 +5,9 @@ import { Icon } from '../Icon/Icon';
 interface CategoryBadgeProps {
   category: keyof (typeof iconPaths)['category'];
   label: string;
-  icon: keyof (typeof iconPaths)['category'];
 }
 
-export const CategoryBadge = ({
-  category,
-  label,
-  icon,
-}: CategoryBadgeProps) => {
+export const CategoryBadge = ({ category, label }: CategoryBadgeProps) => {
   const bg = categoryColors[category];
 
   return (
@@ -23,7 +18,12 @@ export const CategoryBadge = ({
         color: 'var(--color-textPrimary)',
       }}
     >
-      <Icon className='align-middle' group='category' name={icon} size={14} />
+      <Icon
+        className='align-middle'
+        group='category'
+        name={category}
+        size={14}
+      />
       <span className='align-middle'>{label}</span>
     </div>
   );

--- a/packages/ui/src/components/Badge/CategoryBadge.tsx
+++ b/packages/ui/src/components/Badge/CategoryBadge.tsx
@@ -1,0 +1,30 @@
+import { categoryColors } from '../../tokens/categoryColors';
+import { iconPaths } from '../../tokens/iconPath';
+import { Icon } from '../Icon/Icon';
+
+interface CategoryBadgeProps {
+  category: keyof (typeof iconPaths)['category'];
+  label: string;
+  icon: keyof (typeof iconPaths)['category'];
+}
+
+export const CategoryBadge = ({
+  category,
+  label,
+  icon,
+}: CategoryBadgeProps) => {
+  const bg = categoryColors[category];
+
+  return (
+    <div
+      className='inline-flex h-8 items-center gap-1.5 rounded-full px-3 py-1 text-sm font-medium shadow-sm'
+      style={{
+        backgroundColor: bg,
+        color: 'var(--color-textPrimary)',
+      }}
+    >
+      <Icon className='align-middle' group='category' name={icon} size={14} />
+      <span className='align-middle'>{label}</span>
+    </div>
+  );
+};

--- a/packages/ui/src/tokens/categoryColors.ts
+++ b/packages/ui/src/tokens/categoryColors.ts
@@ -1,0 +1,15 @@
+export const categoryColors = {
+  cafe: '#FFE08C',
+  restaurant: '#FFD3B6',
+  hotel: '#C7A061',
+  museum: '#B6D4FF',
+  artGallery: '#D6C2F0',
+  pension: '#C8E6C9',
+  petSupplies: '#FFE3E3',
+  petHospital: '#D6EAF8',
+  petPharmacy: '#E8F5E9',
+  grooming: '#FFECB3',
+  culturalCenter: '#F8D7DA',
+  travelSpot: '#FFF3C4',
+  entrustedCare: '#E0E0E0',
+} as const;

--- a/packages/ui/src/tokens/categoryLabels.ts
+++ b/packages/ui/src/tokens/categoryLabels.ts
@@ -1,0 +1,15 @@
+export const categoryLabels = {
+  cafe: '카페',
+  restaurant: '식당',
+  hotel: '호텔',
+  museum: '박물관',
+  artGallery: '미술관',
+  pension: '펜션',
+  travelSpot: '여행지',
+  petPharmacy: '동물약국',
+  petHospital: '동물병원',
+  petSupplies: '반려동물용품',
+  grooming: '미용',
+  culturalCenter: '문예회관',
+  entrustedCare: '위탁관리',
+} as const;


### PR DESCRIPTION
## 📌 변경 사항 개요

<!-- 이 PR에서 수행한 변경 사항에 대한 간략한 설명 -->
장소 뱃지 구현

## 📝 상세 내용

<!-- 구현 내용에 대한 자세한 설명 -->
정보를 간략하게 보여주는 카드에 들어가는 장소 배지를 구현
총 14개로 구현

## 🔗 관련 이슈

<!-- 관련된 이슈 번호 (예: Resolves: #123) -->

Resolves: #11


## 🖼️ 스크린샷(선택사항)

<!-- UI 변경이 있는 경우 변경 전/후 스크린샷 -->
<img width="1152" height="542" alt="image" src="https://github.com/user-attachments/assets/c4e3944f-11bd-4eb6-8fdb-94dd7fc6b13a" />


## 💡 참고 사항
추후 글자 색 변경할 수도 있음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 카테고리별 배지 추가 — 아이콘과 라벨이 포함된 필형 배지로 각 카테고리에 고유 색상이 적용됩니다.
  * 카테고리별 색상 맵과 한글 라벨이 추가되어 UI에서 일관된 표현이 가능합니다.

* **문서 / 데모**
  * 스토리북 데모 추가 — 전체 카테고리 샘플과 카페/레스토랑 예시를 통해 배지 사용을 확인할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->