### PR TITLE
feat: 로그인 페이지 구현 

### DIFF
--- a/apps/web/src/api/auth.ts
+++ b/apps/web/src/api/auth.ts
@@ -10,7 +10,15 @@ import type {
 import { apiClient } from './client';
 
 export const login = async (data: LoginRequest): Promise<LoginApiResponse> => {
-  const response = await apiClient.post<LoginApiResponse>('/users/login', data);
+  const payload = {
+    email: data.email,
+    password_hash: data.password,
+  };
+
+  const response = await apiClient.post<LoginApiResponse>(
+    '/users/login',
+    payload,
+  );
   return response.data;
 };
 

--- a/apps/web/src/api/auth.ts
+++ b/apps/web/src/api/auth.ts
@@ -12,7 +12,7 @@ import { apiClient } from './client';
 export const login = async (data: LoginRequest): Promise<LoginApiResponse> => {
   const payload = {
     email: data.email,
-    password_hash: data.password,
+    password: data.password,
   };
 
   const response = await apiClient.post<LoginApiResponse>(

--- a/apps/web/src/app/login/components/LoginForm.tsx
+++ b/apps/web/src/app/login/components/LoginForm.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { Button } from '@together-dog/ui';
+
+import { AuthInput } from '@/app/signup/components/AuthInput';
+
+import { useLogin } from '../hooks/useLogin';
+
+export const LoginForm = () => {
+  const { email, setEmail, password, setPassword, isPending, handleSubmit } =
+    useLogin();
+
+  const isFormValid = email.trim() !== '' && password.trim() !== '';
+
+  return (
+    <form className='space-y-4' onSubmit={handleSubmit}>
+      <AuthInput
+        id='email'
+        label='이메일'
+        placeholder='이메일 입력'
+        type='email'
+        value={email}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+          setEmail(e.target.value)
+        }
+      />
+
+      <AuthInput
+        id='password'
+        label='비밀번호'
+        placeholder='비밀번호 입력'
+        type='password'
+        value={password}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+          setPassword(e.target.value)
+        }
+      />
+
+      <Button
+        className='mt-6 !w-full !max-w-none font-bold'
+        isDisabled={isPending || !isFormValid}
+        size='lg'
+        type='submit'
+      >
+        {isPending ? '로그인 중...' : '로그인'}
+      </Button>
+    </form>
+  );
+};

--- a/apps/web/src/app/login/hooks/useLogin.ts
+++ b/apps/web/src/app/login/hooks/useLogin.ts
@@ -45,7 +45,7 @@ export const useLogin = () => {
     e.preventDefault();
     setError(null);
 
-    if (!email || !password) {
+    if (!email.trim() || !password.trim()) {
       addToast('이메일과 비밀번호를 모두 입력해주세요.', 'error', 3000);
       return;
     }

--- a/apps/web/src/app/login/hooks/useLogin.ts
+++ b/apps/web/src/app/login/hooks/useLogin.ts
@@ -1,0 +1,64 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+import { getMyInfo } from '@/api/user';
+import { useLoginMutation } from '@/hooks/queries/useAuthMutation';
+import { useAuthStore } from '@/stores/useAuthStore';
+import { useToastStore } from '@/stores/useToastStore';
+import type { User } from '@/types/user';
+
+export const useLogin = () => {
+  const router = useRouter();
+  const { setLogin, setIsLoading, setError } = useAuthStore();
+  const { addToast } = useToastStore();
+
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const { mutate: login, isPending } = useLoginMutation({
+    onSuccess: async () => {
+      try {
+        setIsLoading(true);
+        const userInfoResponse = await getMyInfo();
+        setLogin(userInfoResponse.data as User);
+        addToast('로그인에 성공했습니다.', 'success', 3000);
+        router.push('/');
+      } catch (error) {
+        console.error('Failed to fetch user info after login', error);
+        setError('사용자 정보를 가져오는데 실패했습니다.');
+        addToast('사용자 정보를 불러오는데 실패했습니다.', 'error', 3000);
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    onError: (error: any) => {
+      const errorMessage =
+        error?.response?.data?.message || '이메일 또는 비밀번호가 틀렸습니다.';
+      setError(errorMessage);
+      addToast(errorMessage, 'error', 3000);
+    },
+  });
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError(null);
+
+    if (!email || !password) {
+      addToast('이메일과 비밀번호를 모두 입력해주세요.', 'error', 3000);
+      return;
+    }
+
+    login({ email, password });
+  };
+
+  return {
+    email,
+    setEmail,
+    password,
+    setPassword,
+    isPending,
+    handleSubmit,
+  };
+};

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -1,0 +1,30 @@
+import Link from 'next/link';
+
+import { LoginForm } from './components/LoginForm';
+
+export default function LoginPage() {
+  return (
+    <main className='mx-auto flex w-full max-w-md flex-col px-4 pt-10 md:pt-20'>
+      <div className='mb-8'>
+        <h1 className='flex flex-col items-center justify-center text-xl font-bold text-gray-900 md:text-2xl'>
+          함께하는 강아지, <br /> Together Dog
+        </h1>
+        <p className='mt-2 flex flex-col items-center justify-center text-sm text-gray-400'>
+          투개더 독에 로그인해 주세요!
+        </p>
+      </div>
+
+      <LoginForm />
+
+      <div className='mt-8 text-center text-sm'>
+        <span className='mr-2 text-gray-400'>아직 회원이 아니신가요?</span>
+        <Link
+          className='font-bold text-blue-500 hover:text-blue-600'
+          href='/signup'
+        >
+          1분만에 회원가입 완료
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/signup/hooks/useSignup.ts
+++ b/apps/web/src/app/signup/hooks/useSignup.ts
@@ -5,11 +5,13 @@ import { useRouter } from 'next/navigation';
 import { type ChangeEvent, type FormEvent, useState } from 'react';
 
 import { useSignupMutation } from '@/hooks/queries/useAuthMutation';
+import { useToastStore } from '@/stores/useToastStore';
 
 import { useAuthField } from './useAuthField';
 
 export const useSignup = () => {
   const router = useRouter();
+  const { addToast } = useToastStore();
 
   // 1. 개별 필드별 로직 분리 (Fields Logic)
   const emailField = useAuthField('email');
@@ -27,12 +29,16 @@ export const useSignup = () => {
   // 3. 회원가입 뮤테이션 (Mutation)
   const signupMutation = useSignupMutation({
     onSuccess: () => {
-      alert('회원가입이 완료되었습니다! 로그인해 주세요.');
+      addToast('회원가입이 완료되었습니다! 로그인해 주세요.', 'success', 3000);
       router.push('/login');
     },
     onError: (error) => {
       console.error('회원가입 실패:', error);
-      alert('회원가입 중 오류가 발생했습니다. 다시 시도해 주세요.');
+      addToast(
+        '회원가입 중 오류가 발생했습니다. 다시 시도해 주세요.',
+        'error',
+        3000,
+      );
     },
   });
 
@@ -41,7 +47,7 @@ export const useSignup = () => {
     e.preventDefault();
 
     if (!emailField.isChecked || !nicknameField.isChecked) {
-      alert('이메일과 닉네임 중복 확인을 해주세요.');
+      addToast('이메일과 닉네임 중복 확인을 해주세요.', 'error', 3000);
       return;
     }
 
@@ -51,7 +57,7 @@ export const useSignup = () => {
       !passwordField.isValid ||
       !nicknameField.isValid
     ) {
-      alert('입력 정보를 다시 확인해 주세요.');
+      addToast('입력 정보를 다시 확인해 주세요.', 'error', 3000);
       return;
     }
 

--- a/apps/web/src/hooks/queries/useAuthMutation.ts
+++ b/apps/web/src/hooks/queries/useAuthMutation.ts
@@ -1,9 +1,10 @@
 'use client';
 
+import { CONSTANTS } from '@shared/config/constants';
 import { useMutation } from '@tanstack/react-query';
 
-import { checkEmail, checkNickname, signup } from '@/api/auth';
-import { SignupRequest } from '@/types/auth';
+import { checkEmail, checkNickname, login, signup } from '@/api/auth';
+import { LoginRequest, SignupRequest } from '@/types/auth';
 
 interface UseSignupMutationProps {
   onSuccess?: () => void;
@@ -21,6 +22,42 @@ export const useSignupMutation = ({
     },
     onSuccess: () => {
       // 성공 시 콜백 실행 (예: 로그인 페이지 이동)
+      onSuccess?.();
+    },
+    onError: (error) => {
+      onError?.(error);
+    },
+  });
+};
+
+interface UseLoginMutationProps {
+  onSuccess?: () => void;
+  onError?: (error: unknown) => void;
+}
+
+export const useLoginMutation = ({
+  onSuccess,
+  onError,
+}: UseLoginMutationProps = {}) => {
+  return useMutation({
+    mutationFn: async ({ email, password }: LoginRequest) => {
+      const response = await login({ email, password });
+      return response;
+    },
+    onSuccess: (response) => {
+      const data = response.data;
+      if (typeof window !== 'undefined' && data) {
+        localStorage.setItem(
+          CONSTANTS.STORAGE_KEYS.AUTH_TOKEN,
+          data.accessToken,
+        );
+        if (data.refreshToken) {
+          localStorage.setItem(
+            `${CONSTANTS.STORAGE_KEYS.AUTH_TOKEN}_refresh`,
+            data.refreshToken,
+          );
+        }
+      }
       onSuccess?.();
     },
     onError: (error) => {

--- a/apps/web/src/hooks/queries/useAuthMutation.ts
+++ b/apps/web/src/hooks/queries/useAuthMutation.ts
@@ -46,14 +46,14 @@ export const useLoginMutation = ({
     },
     onSuccess: (response) => {
       const data = response.data;
-      if (typeof window !== 'undefined' && data) {
+      if (typeof window !== 'undefined' && data?.accessToken) {
         localStorage.setItem(
           CONSTANTS.STORAGE_KEYS.AUTH_TOKEN,
           data.accessToken,
         );
         if (data.refreshToken) {
           localStorage.setItem(
-            `${CONSTANTS.STORAGE_KEYS.AUTH_TOKEN}_refresh`,
+            CONSTANTS.STORAGE_KEYS.REFRESH_TOKEN,
             data.refreshToken,
           );
         }

--- a/apps/web/src/hooks/queries/useAuthMutation.ts
+++ b/apps/web/src/hooks/queries/useAuthMutation.ts
@@ -57,8 +57,8 @@ export const useLoginMutation = ({
             data.refreshToken,
           );
         }
+        onSuccess?.();
       }
-      onSuccess?.();
     },
     onError: (error) => {
       onError?.(error);

--- a/apps/web/src/hooks/queries/useAuthMutation.ts
+++ b/apps/web/src/hooks/queries/useAuthMutation.ts
@@ -57,8 +57,12 @@ export const useLoginMutation = ({
             data.refreshToken,
           );
         }
-        onSuccess?.();
+      } else {
+        console.warn(
+          'Login successful but no accessToken received from server.',
+        );
       }
+      onSuccess?.();
     },
     onError: (error) => {
       onError?.(error);

--- a/apps/web/src/shared/config/constants.ts
+++ b/apps/web/src/shared/config/constants.ts
@@ -1,6 +1,7 @@
 export const CONSTANTS = {
   STORAGE_KEYS: {
     AUTH_TOKEN: 'together_dog_auth_token',
+    REFRESH_TOKEN: 'together_dog_refresh_token',
     USER: 'together_dog_user_info',
   },
 } as const;

--- a/apps/web/src/stores/useAuthStore.ts
+++ b/apps/web/src/stores/useAuthStore.ts
@@ -62,12 +62,6 @@ export const useAuthStore = create<AuthState>()(
       partialize: (state) => ({
         isLoggedIn: state.isLoggedIn,
       }),
-      onRehydrateStorage: () => (state) => {
-        if (state && !state.isLoggedIn && typeof window !== 'undefined') {
-          localStorage.removeItem(CONSTANTS.STORAGE_KEYS.AUTH_TOKEN);
-          localStorage.removeItem(CONSTANTS.STORAGE_KEYS.REFRESH_TOKEN);
-        }
-      },
     },
   ),
 );

--- a/apps/web/src/stores/useAuthStore.ts
+++ b/apps/web/src/stores/useAuthStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+import { createJSONStorage, persist } from 'zustand/middleware';
 
 import { User } from '@/types/user';
 
@@ -51,6 +51,10 @@ export const useAuthStore = create<AuthState>()(
     }),
     {
       name: 'auth-storage',
+      storage: createJSONStorage(() => sessionStorage),
+      partialize: (state) => ({
+        isLoggedIn: state.isLoggedIn,
+      }),
     },
   ),
 );

--- a/apps/web/src/stores/useAuthStore.ts
+++ b/apps/web/src/stores/useAuthStore.ts
@@ -1,3 +1,4 @@
+import { CONSTANTS } from '@shared/config/constants';
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 
@@ -45,7 +46,13 @@ export const useAuthStore = create<AuthState>()(
 
       // 상태 변경 액션들
       setLogin: (user: User) => set({ isLoggedIn: true, user }),
-      setLogout: () => set({ ...initialState }),
+      setLogout: () => {
+        if (typeof window !== 'undefined') {
+          localStorage.removeItem(CONSTANTS.STORAGE_KEYS.AUTH_TOKEN);
+          localStorage.removeItem(CONSTANTS.STORAGE_KEYS.REFRESH_TOKEN);
+        }
+        set({ ...initialState });
+      },
       setIsLoading: (isLoading: boolean) => set({ isLoading }),
       setError: (error: string | null) => set({ error }),
     }),
@@ -55,6 +62,12 @@ export const useAuthStore = create<AuthState>()(
       partialize: (state) => ({
         isLoggedIn: state.isLoggedIn,
       }),
+      onRehydrateStorage: () => (state) => {
+        if (state && !state.isLoggedIn && typeof window !== 'undefined') {
+          localStorage.removeItem(CONSTANTS.STORAGE_KEYS.AUTH_TOKEN);
+          localStorage.removeItem(CONSTANTS.STORAGE_KEYS.REFRESH_TOKEN);
+        }
+      },
     },
   ),
 );

--- a/apps/web/src/stores/useAuthStore.ts
+++ b/apps/web/src/stores/useAuthStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
 import { User } from '@/types/user';
 
@@ -37,12 +38,19 @@ const initialState = {
  * const { isLoggedIn, user, isLoading, error } = useAuthStore();
  * const { setLogin, setLogout, setIsLoading, setError } = useAuthStore();
  */
-export const useAuthStore = create<AuthState>((set) => ({
-  ...initialState,
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set) => ({
+      ...initialState,
 
-  // 상태 변경 액션들
-  setLogin: (user: User) => set({ isLoggedIn: true, user }),
-  setLogout: () => set({ ...initialState }),
-  setIsLoading: (isLoading: boolean) => set({ isLoading }),
-  setError: (error: string | null) => set({ error }),
-}));
+      // 상태 변경 액션들
+      setLogin: (user: User) => set({ isLoggedIn: true, user }),
+      setLogout: () => set({ ...initialState }),
+      setIsLoading: (isLoading: boolean) => set({ isLoading }),
+      setError: (error: string | null) => set({ error }),
+    }),
+    {
+      name: 'auth-storage',
+    },
+  ),
+);


### PR DESCRIPTION
## 📌 변경 사항 개요

이메일/비밀번호 기반의 기본 로그인 기능 구현 및 상태 유지(Session) 로직을 개발했습니다. 더불어 회원가입 UX 개선 및 프론트엔드 보안 스토리지 저장 로직을 강화했습니다.

## 📝 상세 내용

**1. 로그인 UI 및 비즈니스 로직 연동**
- `LoginForm`, `useLogin` 훅 및 `/login` 페이지 컴포넌트 신규 구현
- 백엔드 `LoginRequestDto` 스펙에 맞춰 JSON 페이로드(`password_hash`) 매핑 
- `useLoginMutation` 훅 추가 및 로그인 성공 후 `localStorage` 토큰 저장 로직 구현
- 토큰 저장 로직의 Race Condition을 방지하기 위해 `localStorage.setItem` 완료 후 `onSuccess` 콜백이 안전하게 동작하도록 실행 시점 보장

**2. Zustand `useAuthStore` 상태 영속성(Persist) 및 보안 강화**
- Zustand `persist` 미들웨어 적용으로 새로고침 시에도 로그인 상태(`isLoggedIn`) 유지
- 탭/브라우저 종료 시 세션이 초기화되도록 기본 `localStorage` 대신 `sessionStorage` 사용하도록 변경
- `partialize` 옵션을 통해 `isLoggedIn` 플래그만 세션 스토리지에 저장하고, 민감 정보(`user` 정보)와 일시적 상태(`isLoading`, `error`)를 전면 배제하여 PII 노출 방지

**3. 회원가입 폼 UX(알림) 개선**
- 기존 브라우저 기본 `alert()` 및 `console.error`로 처리하던 회원가입 결과 알림을 `useToastStore(addToast)`로 전면 마이그레이션하여 통일성 있는 UI/UX 제공

## 🔗 관련 이슈

- Resolves: #37

## 🖼️ 스크린샷(선택사항)



## 💡 참고 사항

- 백엔드의 `@RequestBody` 누락으로 인한 400 에러 및 필드명 불일치 현상은 프론트엔드 페이로드를 스펙(`password_hash`)에 맞춘 후 해결되었습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 로그인 페이지 및 로그인 폼 추가
  * 로그인 흐름(토큰 저장, 사용자 정보 로드) 및 전환 동작 추가
  * 토스트 기반 사용자 알림 도입(기존 알림 대체)

* **Refactor**
  * 인증 상태를 세션 저장소에 지속화하고 자동 복원/정리 로직 강화
  * 로그아웃 시 클라이언트 토큰 정리 동작 개선

* **Chores**
  * 인증 관련 상수에 새 저장 키 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->