### PR TITLE
feat: 마이 페이지 구현  

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,7 +1,7 @@
+import withBundleAnalyzer from '@next/bundle-analyzer';
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  /* config options here */
   transpilePackages: ['@together-dog/ui'],
   images: {
     remotePatterns: [
@@ -15,10 +15,14 @@ const nextConfig: NextConfig = {
     return [
       {
         source: '/api/:path*',
-        destination: `${process.env.API_URL || 'http://localhost:8080'}/:path*`, // Proxy to Backend
+        destination: `${process.env.API_URL || 'http://localhost:8080'}/:path*`,
       },
     ];
   },
 };
 
-export default nextConfig;
+const analyzer = withBundleAnalyzer({
+  enabled: process.env.ANALYZE === 'true',
+});
+
+export default analyzer(nextConfig);

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,6 +23,7 @@
     "zustand": "^5.0.9"
   },
   "devDependencies": {
+    "@next/bundle-analyzer": "^16.1.6",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/apps/web/src/api/place.ts
+++ b/apps/web/src/api/place.ts
@@ -75,10 +75,18 @@ export const getPlaceReviews = async (
 
 // 장소 찜하기
 export const likePlace = async (placeId: number): Promise<void> => {
-  await apiClient.post(`/places/${placeId}/like`, {});
+  await apiClient.post(`/places/${placeId}/like`, null, {
+    headers: {
+      'Content-Type': false,
+    },
+  });
 };
 
 // 장소 찜 취소하기
 export const unlikePlace = async (placeId: number): Promise<void> => {
-  await apiClient.delete(`/places/${placeId}/like`);
+  await apiClient.delete(`/places/${placeId}/like`, {
+    headers: {
+      'Content-Type': false,
+    },
+  });
 };

--- a/apps/web/src/api/place.ts
+++ b/apps/web/src/api/place.ts
@@ -75,18 +75,10 @@ export const getPlaceReviews = async (
 
 // 장소 찜하기
 export const likePlace = async (placeId: number): Promise<void> => {
-  await apiClient.post(`/places/${placeId}/like`, null, {
-    headers: {
-      'Content-Type': false,
-    },
-  });
+  await apiClient.post(`/places/${placeId}/like`, null);
 };
 
 // 장소 찜 취소하기
 export const unlikePlace = async (placeId: number): Promise<void> => {
-  await apiClient.delete(`/places/${placeId}/like`, {
-    headers: {
-      'Content-Type': false,
-    },
-  });
+  await apiClient.delete(`/places/${placeId}/like`);
 };

--- a/apps/web/src/api/place.ts
+++ b/apps/web/src/api/place.ts
@@ -75,7 +75,7 @@ export const getPlaceReviews = async (
 
 // 장소 찜하기
 export const likePlace = async (placeId: number): Promise<void> => {
-  await apiClient.post(`/places/${placeId}/like`);
+  await apiClient.post(`/places/${placeId}/like`, {});
 };
 
 // 장소 찜 취소하기

--- a/apps/web/src/api/review.ts
+++ b/apps/web/src/api/review.ts
@@ -2,6 +2,7 @@ import type {
   CreateReviewApiResponse,
   CreateReviewRequest,
   MyReviewsApiResponse,
+  MyReviewsResponse,
   UpdateReviewApiResponse,
   UpdateReviewRequest,
 } from '@/types/review';
@@ -102,9 +103,9 @@ export const deleteReview = async (
 export const getMyReviews = async (
   page = 0,
   size = 10,
-): Promise<MyReviewsApiResponse> => {
+): Promise<MyReviewsResponse> => {
   const response = await apiClient.get<MyReviewsApiResponse>('/users/reviews', {
     params: { page, size },
   });
-  return response.data;
+  return response.data.data;
 };

--- a/apps/web/src/api/user.ts
+++ b/apps/web/src/api/user.ts
@@ -40,3 +40,13 @@ export const changePassword = async (
 export const deleteUser = async (): Promise<void> => {
   await apiClient.delete('/users/delete');
 };
+
+// 찜한 장소 ID 목록 조회
+export const getMyLikedPlaceIds = async (): Promise<number[]> => {
+  const response = await apiClient.get<{
+    status: number;
+    message: string;
+    data: number[];
+  }>('/users/likes');
+  return response.data.data;
+};

--- a/apps/web/src/app/my/components/AccountActions.tsx
+++ b/apps/web/src/app/my/components/AccountActions.tsx
@@ -20,9 +20,11 @@ export const AccountActions = () => {
       addToast('로그아웃 되었습니다.', 'success');
       router.push('/');
     },
-    onError: () => {
+    onError: (error) => {
       // 서버 에러여도 로컬 상태는 초기화
       setLogout();
+      addToast('로그아웃 중 오류가 발생했습니다.', 'error');
+      console.error('Logout error:', error);
       router.push('/');
     },
   });

--- a/apps/web/src/app/my/components/AccountActions.tsx
+++ b/apps/web/src/app/my/components/AccountActions.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+import {
+  useDeleteAccountMutation,
+  useLogoutMutation,
+} from '@/hooks/queries/useUserQuery';
+import { useAuthStore } from '@/stores/useAuthStore';
+import { useModalStore } from '@/stores/useModalStore';
+import { useToastStore } from '@/stores/useToastStore';
+
+export const AccountActions = () => {
+  const router = useRouter();
+  const { setLogout } = useAuthStore();
+  const { openModal, closeModal } = useModalStore();
+  const { addToast } = useToastStore();
+
+  const { mutate: logoutMutate, isPending: isLoggingOut } = useLogoutMutation({
+    onSuccess: () => {
+      setLogout();
+      addToast('로그아웃 되었습니다.', 'success');
+      router.push('/');
+    },
+    onError: () => {
+      // 서버 에러여도 로컬 상태는 초기화
+      setLogout();
+      router.push('/');
+    },
+  });
+
+  const { mutate: deleteAccount, isPending: isDeleting } =
+    useDeleteAccountMutation({
+      onSuccess: () => {
+        setLogout();
+        addToast('회원 탈퇴가 완료되었습니다.', 'default');
+        router.push('/');
+      },
+      onError: () => {
+        addToast('회원 탈퇴에 실패했습니다.', 'error');
+      },
+    });
+
+  const handleLogout = () => {
+    openModal({
+      title: '로그아웃',
+      content: '정말 로그아웃 하시겠습니까?',
+      primaryAction: {
+        label: '로그아웃',
+        onClick: () => {
+          closeModal();
+          logoutMutate();
+        },
+      },
+      secondaryAction: {
+        label: '취소',
+        onClick: closeModal,
+      },
+    });
+  };
+
+  const handleDeleteAccount = () => {
+    openModal({
+      title: '⚠️ 회원 탈퇴',
+      content:
+        '정말로 탈퇴하시겠습니까?\n탈퇴 후에는 모든 데이터가 삭제되며 복구할 수 없습니다.',
+      primaryAction: {
+        label: '탈퇴하기',
+        onClick: () => {
+          closeModal();
+          deleteAccount();
+        },
+      },
+      secondaryAction: {
+        label: '취소',
+        onClick: closeModal,
+      },
+    });
+  };
+
+  return (
+    <section className='space-y-3'>
+      {/* 로그아웃 */}
+      <button
+        className='w-full rounded-2xl border border-gray-100 bg-white p-4 text-left text-sm font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50'
+        disabled={isLoggingOut}
+        type='button'
+        onClick={handleLogout}
+      >
+        {isLoggingOut ? '로그아웃 중...' : '로그아웃'}
+      </button>
+
+      {/* 회원 탈퇴 */}
+      <button
+        className='w-full rounded-2xl border border-red-100 bg-white p-4 text-left text-sm font-medium text-red-500 shadow-sm transition-colors hover:bg-red-50'
+        disabled={isDeleting}
+        type='button'
+        onClick={handleDeleteAccount}
+      >
+        {isDeleting ? '탈퇴 처리 중...' : '회원 탈퇴'}
+      </button>
+    </section>
+  );
+};

--- a/apps/web/src/app/my/components/AccountActions.tsx
+++ b/apps/web/src/app/my/components/AccountActions.tsx
@@ -2,10 +2,8 @@
 
 import { useRouter } from 'next/navigation';
 
-import {
-  useDeleteAccountMutation,
-  useLogoutMutation,
-} from '@/hooks/queries/useUserQuery';
+import { useLogoutMutation } from '@/hooks/queries/useAuthMutation';
+import { useDeleteAccountMutation } from '@/hooks/queries/useUserQuery';
 import { useAuthStore } from '@/stores/useAuthStore';
 import { useModalStore } from '@/stores/useModalStore';
 import { useToastStore } from '@/stores/useToastStore';

--- a/apps/web/src/app/my/components/ChangePasswordForm.tsx
+++ b/apps/web/src/app/my/components/ChangePasswordForm.tsx
@@ -10,7 +10,6 @@ export const ChangePasswordForm = () => {
   const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
-  const [isOpen, setIsOpen] = useState(false);
   const { addToast } = useToastStore();
 
   const { mutate: changePassword, isPending } = useChangePasswordMutation({
@@ -19,7 +18,6 @@ export const ChangePasswordForm = () => {
       setCurrentPassword('');
       setNewPassword('');
       setConfirmPassword('');
-      setIsOpen(false);
     },
     onError: () => {
       addToast(
@@ -52,36 +50,15 @@ export const ChangePasswordForm = () => {
     newPassword === confirmPassword &&
     newPassword.length >= 8;
 
-  if (!isOpen) {
-    return (
-      <section className='rounded-2xl border border-gray-100 bg-white p-6 shadow-sm'>
-        <div className='flex items-center justify-between'>
-          <div>
-            <h3 className='text-sm font-semibold text-gray-500'>비밀번호</h3>
-            <p className='mt-1 text-sm text-gray-400'>••••••••</p>
-          </div>
-          <Button
-            className='text-sm'
-            size='sm'
-            type='button'
-            onClick={() => setIsOpen(true)}
-          >
-            변경
-          </Button>
-        </div>
-      </section>
-    );
-  }
-
   return (
-    <section className='rounded-2xl border border-gray-100 bg-white p-6 shadow-sm'>
-      <h3 className='mb-4 text-sm font-semibold text-gray-500'>
-        비밀번호 변경
-      </h3>
-      <form className='space-y-3' onSubmit={handleSubmit}>
-        <div className='space-y-1'>
+    <div className='space-y-4'>
+      <h3 className='text-sm font-semibold text-gray-500'>비밀번호 변경</h3>
+
+      <form className='space-y-4' onSubmit={handleSubmit}>
+        {/* 현재 비밀번호 */}
+        <div className='space-y-1.5'>
           <label
-            className='ml-1 text-sm font-bold text-gray-700'
+            className='text-xs font-medium text-gray-500'
             htmlFor='current-password'
           >
             현재 비밀번호
@@ -98,72 +75,63 @@ export const ChangePasswordForm = () => {
           />
         </div>
 
-        <div className='space-y-1'>
-          <label
-            className='ml-1 text-sm font-bold text-gray-700'
-            htmlFor='new-password'
-          >
-            새 비밀번호
-          </label>
-          <Input
-            className='h-11'
-            id='new-password'
-            placeholder='새 비밀번호 (8자 이상)'
-            type='password'
-            value={newPassword}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-              setNewPassword(e.target.value)
-            }
-          />
+        {/* 새 비밀번호 + 확인 (2열 그리드) */}
+        <div className='grid grid-cols-1 gap-4 sm:grid-cols-2'>
+          <div className='space-y-1.5'>
+            <label
+              className='text-xs font-medium text-gray-500'
+              htmlFor='new-password'
+            >
+              새 비밀번호
+            </label>
+            <Input
+              className='h-11'
+              id='new-password'
+              placeholder='새 비밀번호 (8자 이상)'
+              type='password'
+              value={newPassword}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                setNewPassword(e.target.value)
+              }
+            />
+          </div>
+
+          <div className='space-y-1.5'>
+            <label
+              className='text-xs font-medium text-gray-500'
+              htmlFor='confirm-password'
+            >
+              비밀번호 확인
+            </label>
+            <Input
+              className='h-11'
+              id='confirm-password'
+              placeholder='비밀번호 다시 입력'
+              type='password'
+              value={confirmPassword}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                setConfirmPassword(e.target.value)
+              }
+            />
+          </div>
         </div>
 
-        <div className='space-y-1'>
-          <label
-            className='ml-1 text-sm font-bold text-gray-700'
-            htmlFor='confirm-password'
-          >
-            새 비밀번호 확인
-          </label>
-          <Input
-            className='h-11'
-            id='confirm-password'
-            placeholder='새 비밀번호 다시 입력'
-            type='password'
-            value={confirmPassword}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-              setConfirmPassword(e.target.value)
-            }
-          />
-          {confirmPassword && newPassword !== confirmPassword && (
-            <p className='ml-1 text-xs text-red-500'>
-              비밀번호가 일치하지 않습니다.
-            </p>
-          )}
-        </div>
+        {confirmPassword && newPassword !== confirmPassword && (
+          <p className='text-xs text-red-500'>비밀번호가 일치하지 않습니다.</p>
+        )}
 
-        <div className='flex gap-2 pt-2'>
+        {/* 저장하기 버튼 */}
+        <div className='flex justify-end pt-2'>
           <Button
-            className='flex-1 text-sm'
+            className='text-sm'
             isDisabled={isPending || !isFormValid}
-            size='sm'
+            size='md'
             type='submit'
           >
-            {isPending ? '변경 중...' : '비밀번호 변경'}
+            {isPending ? '변경 중...' : '저장하기'}
           </Button>
-          <button
-            className='rounded-lg px-4 py-2 text-sm text-gray-500 transition-colors hover:bg-gray-100'
-            type='button'
-            onClick={() => {
-              setCurrentPassword('');
-              setNewPassword('');
-              setConfirmPassword('');
-              setIsOpen(false);
-            }}
-          >
-            취소
-          </button>
         </div>
       </form>
-    </section>
+    </div>
   );
 };

--- a/apps/web/src/app/my/components/ChangePasswordForm.tsx
+++ b/apps/web/src/app/my/components/ChangePasswordForm.tsx
@@ -1,0 +1,169 @@
+'use client';
+
+import { Button, Input } from '@together-dog/ui';
+import { useState } from 'react';
+
+import { useChangePasswordMutation } from '@/hooks/queries/useUserQuery';
+import { useToastStore } from '@/stores/useToastStore';
+
+export const ChangePasswordForm = () => {
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [isOpen, setIsOpen] = useState(false);
+  const { addToast } = useToastStore();
+
+  const { mutate: changePassword, isPending } = useChangePasswordMutation({
+    onSuccess: () => {
+      addToast('비밀번호가 변경되었습니다.', 'success');
+      setCurrentPassword('');
+      setNewPassword('');
+      setConfirmPassword('');
+      setIsOpen(false);
+    },
+    onError: () => {
+      addToast(
+        '비밀번호 변경에 실패했습니다. 현재 비밀번호를 확인해주세요.',
+        'error',
+      );
+    },
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (newPassword !== confirmPassword) {
+      addToast('새 비밀번호가 일치하지 않습니다.', 'error');
+      return;
+    }
+
+    if (newPassword.length < 8) {
+      addToast('비밀번호는 8자 이상이어야 합니다.', 'error');
+      return;
+    }
+
+    changePassword({ currentPassword, newPassword });
+  };
+
+  const isFormValid =
+    currentPassword.trim() !== '' &&
+    newPassword.trim() !== '' &&
+    confirmPassword.trim() !== '' &&
+    newPassword === confirmPassword &&
+    newPassword.length >= 8;
+
+  if (!isOpen) {
+    return (
+      <section className='rounded-2xl border border-gray-100 bg-white p-6 shadow-sm'>
+        <div className='flex items-center justify-between'>
+          <div>
+            <h3 className='text-sm font-semibold text-gray-500'>비밀번호</h3>
+            <p className='mt-1 text-sm text-gray-400'>••••••••</p>
+          </div>
+          <Button
+            className='text-sm'
+            size='sm'
+            type='button'
+            onClick={() => setIsOpen(true)}
+          >
+            변경
+          </Button>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className='rounded-2xl border border-gray-100 bg-white p-6 shadow-sm'>
+      <h3 className='mb-4 text-sm font-semibold text-gray-500'>
+        비밀번호 변경
+      </h3>
+      <form className='space-y-3' onSubmit={handleSubmit}>
+        <div className='space-y-1'>
+          <label
+            className='ml-1 text-sm font-bold text-gray-700'
+            htmlFor='current-password'
+          >
+            현재 비밀번호
+          </label>
+          <Input
+            className='h-11'
+            id='current-password'
+            placeholder='현재 비밀번호 입력'
+            type='password'
+            value={currentPassword}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setCurrentPassword(e.target.value)
+            }
+          />
+        </div>
+
+        <div className='space-y-1'>
+          <label
+            className='ml-1 text-sm font-bold text-gray-700'
+            htmlFor='new-password'
+          >
+            새 비밀번호
+          </label>
+          <Input
+            className='h-11'
+            id='new-password'
+            placeholder='새 비밀번호 (8자 이상)'
+            type='password'
+            value={newPassword}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setNewPassword(e.target.value)
+            }
+          />
+        </div>
+
+        <div className='space-y-1'>
+          <label
+            className='ml-1 text-sm font-bold text-gray-700'
+            htmlFor='confirm-password'
+          >
+            새 비밀번호 확인
+          </label>
+          <Input
+            className='h-11'
+            id='confirm-password'
+            placeholder='새 비밀번호 다시 입력'
+            type='password'
+            value={confirmPassword}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setConfirmPassword(e.target.value)
+            }
+          />
+          {confirmPassword && newPassword !== confirmPassword && (
+            <p className='ml-1 text-xs text-red-500'>
+              비밀번호가 일치하지 않습니다.
+            </p>
+          )}
+        </div>
+
+        <div className='flex gap-2 pt-2'>
+          <Button
+            className='flex-1 text-sm'
+            isDisabled={isPending || !isFormValid}
+            size='sm'
+            type='submit'
+          >
+            {isPending ? '변경 중...' : '비밀번호 변경'}
+          </Button>
+          <button
+            className='rounded-lg px-4 py-2 text-sm text-gray-500 transition-colors hover:bg-gray-100'
+            type='button'
+            onClick={() => {
+              setCurrentPassword('');
+              setNewPassword('');
+              setConfirmPassword('');
+              setIsOpen(false);
+            }}
+          >
+            취소
+          </button>
+        </div>
+      </form>
+    </section>
+  );
+};

--- a/apps/web/src/app/my/components/EditNicknameForm.tsx
+++ b/apps/web/src/app/my/components/EditNicknameForm.tsx
@@ -1,9 +1,13 @@
 'use client';
 
 import { Button, Input } from '@together-dog/ui';
+import { useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 
-import { useUpdateNicknameMutation } from '@/hooks/queries/useUserQuery';
+import {
+  useUpdateNicknameMutation,
+  userKeys,
+} from '@/hooks/queries/useUserQuery';
 import { useToastStore } from '@/stores/useToastStore';
 
 interface EditNicknameFormProps {
@@ -16,9 +20,12 @@ export const EditNicknameForm = ({
   const [nickname, setNickname] = useState(currentNickname);
   const [isEditing, setIsEditing] = useState(false);
   const { addToast } = useToastStore();
+  const queryClient = useQueryClient();
 
   const { mutate: updateNickname, isPending } = useUpdateNicknameMutation({
-    onSuccess: () => {
+    onSuccess: async () => {
+      // 캐시 갱신 완료 후 편집 모드 종료 (stale 닉네임 깜빡임 방지)
+      await queryClient.invalidateQueries({ queryKey: userKeys.myInfo() });
       addToast('닉네임이 변경되었습니다.', 'success');
       setIsEditing(false);
     },

--- a/apps/web/src/app/my/components/EditNicknameForm.tsx
+++ b/apps/web/src/app/my/components/EditNicknameForm.tsx
@@ -83,9 +83,15 @@ export const EditNicknameForm = ({
             {isPending ? '저장 중...' : '저장'}
           </Button>
           <button
-            className='h-11 shrink-0 rounded-xl px-3 text-sm text-gray-500 transition-colors hover:bg-gray-100'
+            className={`h-11 shrink-0 rounded-xl px-3 text-sm transition-colors ${
+              isPending
+                ? 'cursor-not-allowed text-gray-400 opacity-50'
+                : 'text-gray-500 hover:bg-gray-100'
+            }`}
+            disabled={isPending}
             type='button'
             onClick={() => {
+              if (isPending) return;
               setNickname(currentNickname);
               setIsEditing(false);
             }}

--- a/apps/web/src/app/my/components/EditNicknameForm.tsx
+++ b/apps/web/src/app/my/components/EditNicknameForm.tsx
@@ -34,48 +34,44 @@ export const EditNicknameForm = ({
     updateNickname({ nickname: trimmed });
   };
 
-  if (!isEditing) {
-    return (
-      <section className='rounded-2xl border border-gray-100 bg-white p-6 shadow-sm'>
-        <div className='flex items-center justify-between'>
-          <div>
-            <h3 className='text-sm font-semibold text-gray-500'>닉네임</h3>
-            <p className='mt-1 text-base font-medium text-gray-900'>
-              {currentNickname}
-            </p>
+  return (
+    <div className='space-y-1.5'>
+      <label
+        className='text-sm font-semibold text-gray-500'
+        htmlFor='edit-nickname'
+      >
+        닉네임
+      </label>
+
+      {!isEditing ? (
+        <div className='flex gap-2'>
+          <div className='flex h-11 flex-1 items-center rounded-xl border border-gray-200 px-4 text-sm text-gray-900'>
+            {currentNickname}
           </div>
-          <Button
-            className='text-sm'
-            size='sm'
+          <button
+            className='h-11 shrink-0 rounded-xl border border-gray-200 px-4 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-50'
             type='button'
             onClick={() => setIsEditing(true)}
           >
             수정
-          </Button>
+          </button>
         </div>
-      </section>
-    );
-  }
-
-  return (
-    <section className='rounded-2xl border border-gray-100 bg-white p-6 shadow-sm'>
-      <h3 className='mb-3 text-sm font-semibold text-gray-500'>닉네임 수정</h3>
-      <form className='flex gap-2' onSubmit={handleSubmit}>
-        <div className='flex-1'>
-          <Input
-            className='h-11'
-            id='edit-nickname'
-            placeholder='새 닉네임 입력'
-            type='text'
-            value={nickname}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-              setNickname(e.target.value)
-            }
-          />
-        </div>
-        <div className='flex gap-2'>
+      ) : (
+        <form className='flex gap-2' onSubmit={handleSubmit}>
+          <div className='flex-1'>
+            <Input
+              className='h-11'
+              id='edit-nickname'
+              placeholder='새 닉네임 입력'
+              type='text'
+              value={nickname}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                setNickname(e.target.value)
+              }
+            />
+          </div>
           <Button
-            className='h-11 text-sm'
+            className='h-11 shrink-0 text-sm'
             isDisabled={
               isPending ||
               !nickname.trim() ||
@@ -87,7 +83,7 @@ export const EditNicknameForm = ({
             {isPending ? '저장 중...' : '저장'}
           </Button>
           <button
-            className='h-11 rounded-lg px-3 text-sm text-gray-500 transition-colors hover:bg-gray-100'
+            className='h-11 shrink-0 rounded-xl px-3 text-sm text-gray-500 transition-colors hover:bg-gray-100'
             type='button'
             onClick={() => {
               setNickname(currentNickname);
@@ -96,8 +92,8 @@ export const EditNicknameForm = ({
           >
             취소
           </button>
-        </div>
-      </form>
-    </section>
+        </form>
+      )}
+    </div>
   );
 };

--- a/apps/web/src/app/my/components/EditNicknameForm.tsx
+++ b/apps/web/src/app/my/components/EditNicknameForm.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { Button, Input } from '@together-dog/ui';
+import { useState } from 'react';
+
+import { useUpdateNicknameMutation } from '@/hooks/queries/useUserQuery';
+import { useToastStore } from '@/stores/useToastStore';
+
+interface EditNicknameFormProps {
+  currentNickname: string;
+}
+
+export const EditNicknameForm = ({
+  currentNickname,
+}: EditNicknameFormProps) => {
+  const [nickname, setNickname] = useState(currentNickname);
+  const [isEditing, setIsEditing] = useState(false);
+  const { addToast } = useToastStore();
+
+  const { mutate: updateNickname, isPending } = useUpdateNicknameMutation({
+    onSuccess: () => {
+      addToast('닉네임이 변경되었습니다.', 'success');
+      setIsEditing(false);
+    },
+    onError: () => {
+      addToast('닉네임 변경에 실패했습니다.', 'error');
+    },
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = nickname.trim();
+    if (!trimmed || trimmed === currentNickname) return;
+    updateNickname({ nickname: trimmed });
+  };
+
+  if (!isEditing) {
+    return (
+      <section className='rounded-2xl border border-gray-100 bg-white p-6 shadow-sm'>
+        <div className='flex items-center justify-between'>
+          <div>
+            <h3 className='text-sm font-semibold text-gray-500'>닉네임</h3>
+            <p className='mt-1 text-base font-medium text-gray-900'>
+              {currentNickname}
+            </p>
+          </div>
+          <Button
+            className='text-sm'
+            size='sm'
+            type='button'
+            onClick={() => setIsEditing(true)}
+          >
+            수정
+          </Button>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className='rounded-2xl border border-gray-100 bg-white p-6 shadow-sm'>
+      <h3 className='mb-3 text-sm font-semibold text-gray-500'>닉네임 수정</h3>
+      <form className='flex gap-2' onSubmit={handleSubmit}>
+        <div className='flex-1'>
+          <Input
+            className='h-11'
+            id='edit-nickname'
+            placeholder='새 닉네임 입력'
+            type='text'
+            value={nickname}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setNickname(e.target.value)
+            }
+          />
+        </div>
+        <div className='flex gap-2'>
+          <Button
+            className='h-11 text-sm'
+            isDisabled={
+              isPending ||
+              !nickname.trim() ||
+              nickname.trim() === currentNickname
+            }
+            size='sm'
+            type='submit'
+          >
+            {isPending ? '저장 중...' : '저장'}
+          </Button>
+          <button
+            className='h-11 rounded-lg px-3 text-sm text-gray-500 transition-colors hover:bg-gray-100'
+            type='button'
+            onClick={() => {
+              setNickname(currentNickname);
+              setIsEditing(false);
+            }}
+          >
+            취소
+          </button>
+        </div>
+      </form>
+    </section>
+  );
+};

--- a/apps/web/src/app/my/components/MyPageProfile.tsx
+++ b/apps/web/src/app/my/components/MyPageProfile.tsx
@@ -7,30 +7,41 @@ interface MyPageProfileProps {
 }
 
 export const MyPageProfile = ({ user }: MyPageProfileProps) => {
-  const formattedDate = new Date(user.createdAt).toLocaleDateString('ko-KR', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  });
+  // 백엔드 날짜 형식 변환: "2026-03-10 06-17-27" → "2026-03-10T06:17:27"
+  const parseDate = (dateStr: string) => {
+    if (!dateStr) return null;
+    const normalized = dateStr.replace(
+      /(\d{4}-\d{2}-\d{2})\s(\d{2})-(\d{2})-(\d{2})/,
+      '$1T$2:$3:$4',
+    );
+    const date = new Date(normalized);
+    return isNaN(date.getTime()) ? null : date;
+  };
 
-  // 닉네임 첫 글자로 아바타 표시
+  const parsed = parseDate(user.createdAt);
+  const formattedDate = parsed
+    ? parsed.toLocaleDateString('ko-KR', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      })
+    : '정보 없음';
+
   const initial = user.nickname?.charAt(0)?.toUpperCase() || '?';
 
   return (
-    <section className='rounded-2xl border border-gray-100 bg-white p-6 shadow-sm'>
-      <div className='flex items-center gap-4'>
-        {/* 아바타 */}
-        <div className='flex h-16 w-16 items-center justify-center rounded-full bg-gradient-to-br from-orange-400 to-amber-300 text-2xl font-bold text-white shadow-md'>
-          {initial}
-        </div>
-
-        {/* 사용자 정보 */}
-        <div className='flex flex-col'>
-          <h2 className='text-lg font-bold text-gray-900'>{user.nickname}</h2>
-          <p className='text-sm text-gray-500'>{user.email}</p>
-          <p className='mt-1 text-xs text-gray-400'>가입일: {formattedDate}</p>
-        </div>
+    <div className='flex items-center gap-4'>
+      {/* 아바타 */}
+      <div className='flex h-16 w-16 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-orange-400 to-amber-300 text-2xl font-bold text-white shadow-md'>
+        {initial}
       </div>
-    </section>
+
+      {/* 사용자 정보 */}
+      <div className='flex flex-col'>
+        <h3 className='text-base font-bold text-gray-900'>{user.nickname}</h3>
+        <p className='text-sm text-gray-500'>{user.email}</p>
+        <p className='mt-1 text-xs text-gray-400'>가입일: {formattedDate}</p>
+      </div>
+    </div>
   );
 };

--- a/apps/web/src/app/my/components/MyPageProfile.tsx
+++ b/apps/web/src/app/my/components/MyPageProfile.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { MyInfo } from '@/types/user';
+
+interface MyPageProfileProps {
+  user: MyInfo;
+}
+
+export const MyPageProfile = ({ user }: MyPageProfileProps) => {
+  const formattedDate = new Date(user.createdAt).toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+
+  // 닉네임 첫 글자로 아바타 표시
+  const initial = user.nickname?.charAt(0)?.toUpperCase() || '?';
+
+  return (
+    <section className='rounded-2xl border border-gray-100 bg-white p-6 shadow-sm'>
+      <div className='flex items-center gap-4'>
+        {/* 아바타 */}
+        <div className='flex h-16 w-16 items-center justify-center rounded-full bg-gradient-to-br from-orange-400 to-amber-300 text-2xl font-bold text-white shadow-md'>
+          {initial}
+        </div>
+
+        {/* 사용자 정보 */}
+        <div className='flex flex-col'>
+          <h2 className='text-lg font-bold text-gray-900'>{user.nickname}</h2>
+          <p className='text-sm text-gray-500'>{user.email}</p>
+          <p className='mt-1 text-xs text-gray-400'>가입일: {formattedDate}</p>
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/apps/web/src/app/my/components/MyReviewHistory.tsx
+++ b/apps/web/src/app/my/components/MyReviewHistory.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import Link from 'next/link';
+import { useState } from 'react';
+
+import {
+  useDeleteReviewMutation,
+  useMyReviewsQuery,
+} from '@/hooks/queries/useUserQuery';
+import { useModalStore } from '@/stores/useModalStore';
+import { useToastStore } from '@/stores/useToastStore';
+
+export const MyReviewHistory = () => {
+  const [page, setPage] = useState(0);
+  const { data, isLoading } = useMyReviewsQuery(page, 5);
+  const { openModal, closeModal } = useModalStore();
+  const { addToast } = useToastStore();
+
+  const { mutate: deleteReview } = useDeleteReviewMutation({
+    onSuccess: () => addToast('리뷰가 삭제되었습니다.', 'success'),
+    onError: () => addToast('리뷰 삭제에 실패했습니다.', 'error'),
+  });
+
+  const handleDelete = (placeId: number, reviewId: number) => {
+    openModal({
+      title: '리뷰 삭제',
+      content: '정말 이 리뷰를 삭제하시겠습니까?',
+      primaryAction: {
+        label: '삭제',
+        onClick: () => {
+          closeModal();
+          deleteReview({ placeId, reviewId });
+        },
+      },
+      secondaryAction: { label: '취소', onClick: closeModal },
+    });
+  };
+
+  // 날짜 파싱 헬퍼
+  const formatDate = (dateStr?: string) => {
+    if (!dateStr) return '';
+    const normalized = dateStr.replace(
+      /(\d{4}-\d{2}-\d{2})\s(\d{2})-(\d{2})-(\d{2})/,
+      '$1T$2:$3:$4',
+    );
+    const date = new Date(normalized);
+    if (isNaN(date.getTime())) return dateStr;
+    return date.toLocaleDateString('ko-KR', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    });
+  };
+
+  // 별점 렌더링
+  const renderStars = (rating: number) => {
+    return Array.from({ length: 5 }, (_, i) => (
+      <span key={i} className={i < rating ? 'text-amber-400' : 'text-gray-200'}>
+        ★
+      </span>
+    ));
+  };
+
+  if (isLoading) {
+    return (
+      <div className='flex items-center justify-center py-12'>
+        <div className='h-6 w-6 animate-spin rounded-full border-2 border-orange-400 border-t-transparent' />
+      </div>
+    );
+  }
+
+  const reviews = data?.content || [];
+  const totalElements = data?.totalElements || 0;
+  const totalPages = data?.totalPages || 0;
+
+  return (
+    <section className='rounded-2xl border border-gray-100 bg-white p-6 shadow-sm md:p-8'>
+      <div className='mb-4 flex items-center justify-between'>
+        <h2 className='text-lg font-bold text-gray-900'>My Review History</h2>
+        <span className='text-sm text-gray-400'>총 {totalElements}개</span>
+      </div>
+
+      {reviews.length === 0 ? (
+        <div className='py-12 text-center'>
+          <p className='text-gray-400'>작성한 리뷰가 없습니다.</p>
+          <Link
+            className='mt-2 inline-block text-sm font-medium text-orange-500 hover:text-orange-600'
+            href='/places'
+          >
+            장소 둘러보기 →
+          </Link>
+        </div>
+      ) : (
+        <div className='space-y-4'>
+          {reviews.map((review) => (
+            <div
+              key={review.id}
+              className='rounded-xl border border-gray-100 p-4 transition-colors hover:bg-gray-50'
+            >
+              <div className='flex items-start justify-between'>
+                <div className='min-w-0 flex-1'>
+                  <div className='flex items-center gap-2'>
+                    <span className='text-sm'>
+                      {renderStars(review.rating)}
+                    </span>
+                    <span className='text-xs text-gray-400'>
+                      {formatDate(review.visitDate)}
+                    </span>
+                  </div>
+                  <p className='mt-1.5 line-clamp-2 text-sm text-gray-700'>
+                    {review.content}
+                  </p>
+                </div>
+
+                {/* 수정 / 삭제 */}
+                <div className='ml-3 flex shrink-0 gap-1'>
+                  <Link
+                    className='rounded-lg px-2.5 py-1 text-xs text-gray-500 transition-colors hover:bg-gray-100'
+                    href={`/places/${review.placeId}`}
+                  >
+                    ✏️ 수정
+                  </Link>
+                  <button
+                    className='rounded-lg px-2.5 py-1 text-xs text-red-400 transition-colors hover:bg-red-50'
+                    type='button'
+                    onClick={() => handleDelete(review.placeId, review.id)}
+                  >
+                    🗑️ 삭제
+                  </button>
+                </div>
+              </div>
+            </div>
+          ))}
+
+          {/* 페이지네이션 */}
+          {totalPages > 1 && (
+            <div className='flex items-center justify-center gap-2 pt-2'>
+              <button
+                className='rounded-lg px-3 py-1.5 text-sm text-gray-500 transition-colors hover:bg-gray-100 disabled:opacity-30'
+                disabled={page === 0}
+                type='button'
+                onClick={() => setPage((p) => Math.max(0, p - 1))}
+              >
+                ← 이전
+              </button>
+              <span className='text-xs text-gray-400'>
+                {page + 1} / {totalPages}
+              </span>
+              <button
+                className='rounded-lg px-3 py-1.5 text-sm text-gray-500 transition-colors hover:bg-gray-100 disabled:opacity-30'
+                disabled={page >= totalPages - 1}
+                type='button'
+                onClick={() => setPage((p) => p + 1)}
+              >
+                다음 →
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </section>
+  );
+};

--- a/apps/web/src/app/my/components/MyReviewHistory.tsx
+++ b/apps/web/src/app/my/components/MyReviewHistory.tsx
@@ -55,7 +55,7 @@ export const MyReviewHistory = () => {
   // 별점 렌더링
   const renderStars = (rating: number) => {
     return (
-      <div aria-label={`5점 만점에 ${rating}점`} role='img'>
+      <span aria-label={`5점 만점에 ${rating}점`} role='img'>
         {Array.from({ length: 5 }, (_, i) => (
           <span
             key={i}
@@ -65,14 +65,16 @@ export const MyReviewHistory = () => {
             ★
           </span>
         ))}
-      </div>
+      </span>
     );
   };
 
   if (isLoading) {
     return (
       <section className='rounded-2xl border border-gray-100 bg-white p-6 shadow-sm md:p-8'>
-        <h2 className='mb-4 text-lg font-bold text-gray-900'>My Review History</h2>
+        <h2 className='mb-4 text-lg font-bold text-gray-900'>
+          My Review History
+        </h2>
         <div className='flex items-center justify-center py-12'>
           <div className='h-6 w-6 animate-spin rounded-full border-2 border-orange-400 border-t-transparent' />
         </div>
@@ -83,7 +85,9 @@ export const MyReviewHistory = () => {
   if (isError) {
     return (
       <section className='rounded-2xl border border-gray-100 bg-white p-6 shadow-sm md:p-8'>
-        <h2 className='mb-4 text-lg font-bold text-gray-900'>My Review History</h2>
+        <h2 className='mb-4 text-lg font-bold text-gray-900'>
+          My Review History
+        </h2>
         <div className='py-12 text-center'>
           <p className='text-gray-500'>리뷰를 불러오는 데 실패했습니다.</p>
           <button

--- a/apps/web/src/app/my/components/MyReviewHistory.tsx
+++ b/apps/web/src/app/my/components/MyReviewHistory.tsx
@@ -12,7 +12,7 @@ import { useToastStore } from '@/stores/useToastStore';
 
 export const MyReviewHistory = () => {
   const [page, setPage] = useState(0);
-  const { data, isLoading } = useMyReviewsQuery(page, 5);
+  const { data, isLoading, isError, refetch } = useMyReviewsQuery(page, 5);
   const { openModal, closeModal } = useModalStore();
   const { addToast } = useToastStore();
 
@@ -71,9 +71,30 @@ export const MyReviewHistory = () => {
 
   if (isLoading) {
     return (
-      <div className='flex items-center justify-center py-12'>
-        <div className='h-6 w-6 animate-spin rounded-full border-2 border-orange-400 border-t-transparent' />
-      </div>
+      <section className='rounded-2xl border border-gray-100 bg-white p-6 shadow-sm md:p-8'>
+        <h2 className='mb-4 text-lg font-bold text-gray-900'>My Review History</h2>
+        <div className='flex items-center justify-center py-12'>
+          <div className='h-6 w-6 animate-spin rounded-full border-2 border-orange-400 border-t-transparent' />
+        </div>
+      </section>
+    );
+  }
+
+  if (isError) {
+    return (
+      <section className='rounded-2xl border border-gray-100 bg-white p-6 shadow-sm md:p-8'>
+        <h2 className='mb-4 text-lg font-bold text-gray-900'>My Review History</h2>
+        <div className='py-12 text-center'>
+          <p className='text-gray-500'>리뷰를 불러오는 데 실패했습니다.</p>
+          <button
+            className='mt-3 text-sm font-medium text-orange-500 hover:text-orange-600'
+            type='button'
+            onClick={() => refetch()}
+          >
+            다시 시도
+          </button>
+        </div>
+      </section>
     );
   }
 

--- a/apps/web/src/app/my/components/MyReviewHistory.tsx
+++ b/apps/web/src/app/my/components/MyReviewHistory.tsx
@@ -54,11 +54,19 @@ export const MyReviewHistory = () => {
 
   // 별점 렌더링
   const renderStars = (rating: number) => {
-    return Array.from({ length: 5 }, (_, i) => (
-      <span key={i} className={i < rating ? 'text-amber-400' : 'text-gray-200'}>
-        ★
-      </span>
-    ));
+    return (
+      <div aria-label={`5점 만점에 ${rating}점`} role='img'>
+        {Array.from({ length: 5 }, (_, i) => (
+          <span
+            key={i}
+            aria-hidden='true'
+            className={i < rating ? 'text-amber-400' : 'text-gray-200'}
+          >
+            ★
+          </span>
+        ))}
+      </div>
+    );
   };
 
   if (isLoading) {
@@ -112,13 +120,13 @@ export const MyReviewHistory = () => {
                   </p>
                 </div>
 
-                {/* 수정 / 삭제 */}
+                {/* 장소 보기 / 삭제 */}
                 <div className='ml-3 flex shrink-0 gap-1'>
                   <Link
                     className='rounded-lg px-2.5 py-1 text-xs text-gray-500 transition-colors hover:bg-gray-100'
-                    href={`/places/${review.placeId}`}
+                    href={`/places/${review.placeId}#review-${review.id}`}
                   >
-                    ✏️ 수정
+                    📍 장소 보기
                   </Link>
                   <button
                     className='rounded-lg px-2.5 py-1 text-xs text-red-400 transition-colors hover:bg-red-50'

--- a/apps/web/src/app/my/components/MyWishlist.tsx
+++ b/apps/web/src/app/my/components/MyWishlist.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+
+import { useLikedPlacesQuery } from '@/hooks/queries/useUserQuery';
+import { PlaceDetail } from '@/types/place';
+
+interface MyWishlistProps {
+  likedPlaceIds: number[];
+}
+
+export const MyWishlist = ({ likedPlaceIds }: MyWishlistProps) => {
+  const { data: places, isLoading } = useLikedPlacesQuery(likedPlaceIds);
+
+  const totalCount = likedPlaceIds.length;
+
+  if (isLoading) {
+    return (
+      <section className='rounded-2xl border border-gray-100 bg-white p-6 shadow-sm md:p-8'>
+        <h2 className='mb-4 text-lg font-bold text-gray-900'>
+          My Wishlist (찜 목록)
+        </h2>
+        <div className='flex items-center justify-center py-12'>
+          <div className='h-6 w-6 animate-spin rounded-full border-2 border-orange-400 border-t-transparent' />
+        </div>
+      </section>
+    );
+  }
+
+  const likedPlaces = (places as PlaceDetail[]) || [];
+
+  return (
+    <section className='rounded-2xl border border-gray-100 bg-white p-6 shadow-sm md:p-8'>
+      <div className='mb-4 flex items-center justify-between'>
+        <h2 className='text-lg font-bold text-gray-900'>
+          My Wishlist (찜 목록)
+        </h2>
+        <span className='text-sm text-gray-400'>총 {totalCount}개</span>
+      </div>
+
+      {likedPlaces.length === 0 ? (
+        <div className='py-12 text-center'>
+          <p className='text-gray-400'>찜한 장소가 없습니다.</p>
+          <Link
+            className='mt-2 inline-block text-sm font-medium text-orange-500 hover:text-orange-600'
+            href='/places'
+          >
+            장소 둘러보기 →
+          </Link>
+        </div>
+      ) : (
+        <div className='grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3'>
+          {likedPlaces.map((place) => (
+            <Link
+              key={place.placeInfo.id}
+              className='group overflow-hidden rounded-xl border border-gray-100 transition-shadow hover:shadow-md'
+              href={`/places/${place.placeInfo.id}`}
+            >
+              {/* 썸네일 */}
+              <div className='relative aspect-[4/3] w-full overflow-hidden bg-gray-100'>
+                {place.top3photos?.[0] ? (
+                  <Image
+                    fill
+                    alt={place.placeInfo.name}
+                    className='object-cover transition-transform group-hover:scale-105'
+                    sizes='(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw'
+                    src={place.top3photos[0]}
+                  />
+                ) : (
+                  <div className='flex h-full items-center justify-center text-sm text-gray-300'>
+                    이미지 없음
+                  </div>
+                )}
+              </div>
+
+              {/* 정보 */}
+              <div className='p-3'>
+                <h3 className='text-sm font-bold text-gray-900'>
+                  {place.placeInfo.name}
+                </h3>
+                <p className='mt-0.5 text-xs text-gray-400'>
+                  {place.placeInfo.city} {place.placeInfo.district}
+                  {place.placeInfo.subdistrict
+                    ? ` ${place.placeInfo.subdistrict}`
+                    : ''}
+                </p>
+                {place.placeInfo.averageRating != null && (
+                  <div className='mt-1 flex items-center gap-1'>
+                    <span className='text-xs text-amber-400'>★</span>
+                    <span className='text-xs text-gray-500'>
+                      {place.placeInfo.averageRating.toFixed(1)}
+                    </span>
+                  </div>
+                )}
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+};

--- a/apps/web/src/app/my/components/MyWishlist.tsx
+++ b/apps/web/src/app/my/components/MyWishlist.tsx
@@ -6,14 +6,8 @@ import Link from 'next/link';
 import { useLikedPlacesQuery } from '@/hooks/queries/useUserQuery';
 import { PlaceDetail } from '@/types/place';
 
-interface MyWishlistProps {
-  likedPlaceIds: number[];
-}
-
-export const MyWishlist = ({ likedPlaceIds }: MyWishlistProps) => {
-  const { data: places, isLoading } = useLikedPlacesQuery(likedPlaceIds);
-
-  const totalCount = likedPlaceIds.length;
+export const MyWishlist = () => {
+  const { data: places, isLoading } = useLikedPlacesQuery();
 
   if (isLoading) {
     return (
@@ -36,7 +30,7 @@ export const MyWishlist = ({ likedPlaceIds }: MyWishlistProps) => {
         <h2 className='text-lg font-bold text-gray-900'>
           My Wishlist (찜 목록)
         </h2>
-        <span className='text-sm text-gray-400'>총 {totalCount}개</span>
+        <span className='text-sm text-gray-400'>총 {likedPlaces.length}개</span>
       </div>
 
       {likedPlaces.length === 0 ? (

--- a/apps/web/src/app/my/components/MyWishlist.tsx
+++ b/apps/web/src/app/my/components/MyWishlist.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 
 import { useLikedPlacesQuery } from '@/hooks/queries/useUserQuery';
 import { PlaceDetail } from '@/types/place';
+import { resolveThumbnailPath } from '@/utils/petMapper';
 
 export const MyWishlist = () => {
   const { data: places, isLoading } = useLikedPlacesQuery();
@@ -57,9 +58,9 @@ export const MyWishlist = () => {
                   <Image
                     fill
                     alt={place.placeInfo.name}
-                    className='object-cover transition-transform group-hover:scale-105'
+                    className='object-contain transition-transform group-hover:scale-105'
                     sizes='(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw'
-                    src={place.top3photos[0]}
+                    src={resolveThumbnailPath(place.top3photos[0])}
                   />
                 ) : (
                   <div className='flex h-full items-center justify-center text-sm text-gray-300'>

--- a/apps/web/src/app/my/components/MyWishlist.tsx
+++ b/apps/web/src/app/my/components/MyWishlist.tsx
@@ -76,19 +76,22 @@ export const MyWishlist = () => {
             >
               {/* 썸네일 */}
               <div className='relative aspect-[4/3] w-full overflow-hidden bg-gray-100'>
-                {place.top3photos?.[0] ? (
-                  <Image
-                    fill
-                    alt={place.placeInfo.name}
-                    className='object-contain transition-transform group-hover:scale-105'
-                    sizes='(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw'
-                    src={resolveThumbnailPath(place.top3photos[0])}
-                  />
-                ) : (
-                  <div className='flex h-full items-center justify-center text-sm text-gray-300'>
-                    이미지 없음
-                  </div>
-                )}
+                {(() => {
+                  const thumb = place.top3photos?.[0]?.trim();
+                  return thumb ? (
+                    <Image
+                      fill
+                      alt={place.placeInfo.name}
+                      className='object-contain transition-transform group-hover:scale-105'
+                      sizes='(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw'
+                      src={resolveThumbnailPath(thumb)}
+                    />
+                  ) : (
+                    <div className='flex h-full items-center justify-center text-sm text-gray-300'>
+                      이미지 없음
+                    </div>
+                  );
+                })()}
               </div>
 
               {/* 정보 */}

--- a/apps/web/src/app/my/components/MyWishlist.tsx
+++ b/apps/web/src/app/my/components/MyWishlist.tsx
@@ -8,7 +8,7 @@ import { PlaceDetail } from '@/types/place';
 import { resolveThumbnailPath } from '@/utils/petMapper';
 
 export const MyWishlist = () => {
-  const { data: places, isLoading } = useLikedPlacesQuery();
+  const { data: places, isLoading, isError, refetch } = useLikedPlacesQuery();
 
   if (isLoading) {
     return (
@@ -18,6 +18,28 @@ export const MyWishlist = () => {
         </h2>
         <div className='flex items-center justify-center py-12'>
           <div className='h-6 w-6 animate-spin rounded-full border-2 border-orange-400 border-t-transparent' />
+        </div>
+      </section>
+    );
+  }
+
+  if (isError) {
+    return (
+      <section className='rounded-2xl border border-gray-100 bg-white p-6 shadow-sm md:p-8'>
+        <h2 className='mb-4 text-lg font-bold text-gray-900'>
+          My Wishlist (찜 목록)
+        </h2>
+        <div className='py-12 text-center'>
+          <p className='mb-4 text-red-500'>
+            찜 목록을 불러오는 중 오류가 발생했습니다.
+          </p>
+          <button
+            className='rounded-xl bg-gray-100 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-200'
+            type='button'
+            onClick={() => refetch()}
+          >
+            다시 시도
+          </button>
         </div>
       </section>
     );

--- a/apps/web/src/app/my/page.tsx
+++ b/apps/web/src/app/my/page.tsx
@@ -10,8 +10,10 @@ import { AccountActions } from './components/AccountActions';
 import { ChangePasswordForm } from './components/ChangePasswordForm';
 import { EditNicknameForm } from './components/EditNicknameForm';
 import { MyPageProfile } from './components/MyPageProfile';
+import { MyReviewHistory } from './components/MyReviewHistory';
+import { MyWishlist } from './components/MyWishlist';
 
-type TabType = 'profile' | 'settings';
+type TabType = 'profile' | 'reviews' | 'wishlist' | 'settings';
 
 export default function MyPage() {
   const router = useRouter();
@@ -76,6 +78,8 @@ export default function MyPage() {
 
   const tabs: { key: TabType; label: string; icon: string }[] = [
     { key: 'profile', label: '프로필 관리', icon: '👤' },
+    { key: 'reviews', label: '리뷰 내역', icon: '✍️' },
+    { key: 'wishlist', label: '찜 목록', icon: '❤️' },
     { key: 'settings', label: '설정', icon: '⚙️' },
   ];
 
@@ -161,6 +165,12 @@ export default function MyPage() {
                 <ChangePasswordForm />
               </section>
             </div>
+          )}
+
+          {activeTab === 'reviews' && <MyReviewHistory />}
+
+          {activeTab === 'wishlist' && (
+            <MyWishlist likedPlaceIds={myInfo.likedPlaceIds || []} />
           )}
 
           {activeTab === 'settings' && (

--- a/apps/web/src/app/my/page.tsx
+++ b/apps/web/src/app/my/page.tsx
@@ -169,9 +169,7 @@ export default function MyPage() {
 
           {activeTab === 'reviews' && <MyReviewHistory />}
 
-          {activeTab === 'wishlist' && (
-            <MyWishlist likedPlaceIds={myInfo.likedPlaceIds || []} />
-          )}
+          {activeTab === 'wishlist' && <MyWishlist />}
 
           {activeTab === 'settings' && (
             <section className='rounded-2xl border border-gray-100 bg-white p-6 shadow-sm md:p-8'>

--- a/apps/web/src/app/my/page.tsx
+++ b/apps/web/src/app/my/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import { useMyInfoQuery } from '@/hooks/queries/useUserQuery';
 import { useAuthStore } from '@/stores/useAuthStore';
@@ -11,10 +11,13 @@ import { ChangePasswordForm } from './components/ChangePasswordForm';
 import { EditNicknameForm } from './components/EditNicknameForm';
 import { MyPageProfile } from './components/MyPageProfile';
 
+type TabType = 'profile' | 'settings';
+
 export default function MyPage() {
   const router = useRouter();
   const { isLoggedIn } = useAuthStore();
   const { data: myInfo, isLoading, error } = useMyInfoQuery();
+  const [activeTab, setActiveTab] = useState<TabType>('profile');
 
   // 비로그인 시 로그인 페이지로 리다이렉트
   useEffect(() => {
@@ -23,13 +26,11 @@ export default function MyPage() {
     }
   }, [isLoggedIn, router]);
 
-  if (!isLoggedIn) {
-    return null;
-  }
+  if (!isLoggedIn) return null;
 
   if (isLoading) {
     return (
-      <div className='mx-auto flex min-h-[60vh] max-w-md items-center justify-center'>
+      <div className='mx-auto flex min-h-[60vh] max-w-5xl items-center justify-center'>
         <div className='flex flex-col items-center gap-3'>
           <div className='h-8 w-8 animate-spin rounded-full border-2 border-orange-400 border-t-transparent' />
           <p className='text-sm text-gray-400'>불러오는 중...</p>
@@ -40,7 +41,7 @@ export default function MyPage() {
 
   if (error || !myInfo) {
     return (
-      <div className='mx-auto flex min-h-[60vh] max-w-md items-center justify-center'>
+      <div className='mx-auto flex min-h-[60vh] max-w-5xl items-center justify-center'>
         <div className='text-center'>
           <p className='text-gray-500'>정보를 불러올 수 없습니다.</p>
           <button
@@ -55,28 +56,104 @@ export default function MyPage() {
     );
   }
 
+  const initial = myInfo.nickname?.charAt(0)?.toUpperCase() || '?';
+
+  const tabs: { key: TabType; label: string; icon: string }[] = [
+    { key: 'profile', label: '프로필 관리', icon: '👤' },
+    { key: 'settings', label: '설정', icon: '⚙️' },
+  ];
+
   return (
-    <div className='mx-auto w-full max-w-md px-4 py-8 md:py-12'>
-      {/* 페이지 제목 */}
-      <h1 className='mb-6 text-xl font-bold text-gray-900 md:text-2xl'>
+    <div className='mx-auto w-full max-w-5xl px-4 py-8 md:py-12'>
+      <h1 className='mb-6 text-xl font-bold text-gray-900 md:hidden'>
         마이페이지
       </h1>
 
-      {/* 프로필 카드 */}
-      <div className='space-y-4'>
-        <MyPageProfile user={myInfo} />
+      <div className='flex flex-col gap-6 md:flex-row md:gap-8'>
+        {/* ───── 사이드바 (데스크탑: 왼쪽 고정, 모바일: 상단 가로 스크롤) ───── */}
+        <aside className='w-full shrink-0 md:w-60'>
+          {/* 프로필 카드 */}
+          <div className='rounded-2xl border border-gray-100 bg-white p-6 shadow-sm'>
+            <div className='flex flex-col items-center'>
+              <div className='flex h-20 w-20 items-center justify-center rounded-full bg-gradient-to-br from-orange-400 to-amber-300 text-3xl font-bold text-white shadow-md'>
+                {initial}
+              </div>
+              <h2 className='mt-3 text-base font-bold text-gray-900'>
+                {myInfo.nickname}
+              </h2>
+              <p className='mt-0.5 text-xs text-gray-400'>
+                반려동물과 함께하는 일상
+              </p>
+            </div>
 
-        {/* 닉네임 수정 */}
-        <EditNicknameForm currentNickname={myInfo.nickname} />
+            {/* 탭 네비게이션 */}
+            <nav className='mt-6 space-y-1'>
+              {tabs.map((tab) => (
+                <button
+                  key={tab.key}
+                  className={`flex w-full items-center gap-2.5 rounded-xl px-4 py-2.5 text-left text-sm font-medium transition-colors ${
+                    activeTab === tab.key
+                      ? 'bg-orange-50 text-orange-600'
+                      : 'text-gray-600 hover:bg-gray-50'
+                  }`}
+                  type='button'
+                  onClick={() => setActiveTab(tab.key)}
+                >
+                  <span className='text-base'>{tab.icon}</span>
+                  {tab.label}
+                </button>
+              ))}
+            </nav>
+          </div>
+        </aside>
 
-        {/* 비밀번호 변경 */}
-        <ChangePasswordForm />
+        {/* ───── 메인 콘텐츠 영역 ───── */}
+        <main className='min-w-0 flex-1'>
+          {activeTab === 'profile' && (
+            <div className='space-y-6'>
+              {/* My Profile 섹션 */}
+              <section className='rounded-2xl border border-gray-100 bg-white p-6 shadow-sm md:p-8'>
+                <h2 className='mb-6 text-lg font-bold text-gray-900'>
+                  My Profile
+                </h2>
 
-        {/* 구분선 */}
-        <div className='my-2' />
+                {/* 프로필 정보 */}
+                <MyPageProfile user={myInfo} />
 
-        {/* 로그아웃 / 회원 탈퇴 */}
-        <AccountActions />
+                {/* 구분선 */}
+                <hr className='my-6 border-gray-100' />
+
+                {/* 닉네임 + 이메일 */}
+                <div className='grid grid-cols-1 gap-4 sm:grid-cols-2'>
+                  <EditNicknameForm currentNickname={myInfo.nickname} />
+
+                  {/* 이메일 (읽기 전용) */}
+                  <div className='space-y-1.5'>
+                    <label className='text-sm font-semibold text-gray-500'>
+                      이메일
+                    </label>
+                    <div className='flex h-11 items-center rounded-xl border border-gray-200 bg-gray-50 px-4 text-sm text-gray-500'>
+                      {myInfo.email}
+                    </div>
+                  </div>
+                </div>
+
+                {/* 구분선 */}
+                <hr className='my-6 border-gray-100' />
+
+                {/* 비밀번호 변경 */}
+                <ChangePasswordForm />
+              </section>
+            </div>
+          )}
+
+          {activeTab === 'settings' && (
+            <section className='rounded-2xl border border-gray-100 bg-white p-6 shadow-sm md:p-8'>
+              <h2 className='mb-6 text-lg font-bold text-gray-900'>설정</h2>
+              <AccountActions />
+            </section>
+          )}
+        </main>
       </div>
     </div>
   );

--- a/apps/web/src/app/my/page.tsx
+++ b/apps/web/src/app/my/page.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+
+import { useMyInfoQuery } from '@/hooks/queries/useUserQuery';
+import { useAuthStore } from '@/stores/useAuthStore';
+
+import { AccountActions } from './components/AccountActions';
+import { ChangePasswordForm } from './components/ChangePasswordForm';
+import { EditNicknameForm } from './components/EditNicknameForm';
+import { MyPageProfile } from './components/MyPageProfile';
+
+export default function MyPage() {
+  const router = useRouter();
+  const { isLoggedIn } = useAuthStore();
+  const { data: myInfo, isLoading, error } = useMyInfoQuery();
+
+  // 비로그인 시 로그인 페이지로 리다이렉트
+  useEffect(() => {
+    if (!isLoggedIn) {
+      router.replace('/login');
+    }
+  }, [isLoggedIn, router]);
+
+  if (!isLoggedIn) {
+    return null;
+  }
+
+  if (isLoading) {
+    return (
+      <div className='mx-auto flex min-h-[60vh] max-w-md items-center justify-center'>
+        <div className='flex flex-col items-center gap-3'>
+          <div className='h-8 w-8 animate-spin rounded-full border-2 border-orange-400 border-t-transparent' />
+          <p className='text-sm text-gray-400'>불러오는 중...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !myInfo) {
+    return (
+      <div className='mx-auto flex min-h-[60vh] max-w-md items-center justify-center'>
+        <div className='text-center'>
+          <p className='text-gray-500'>정보를 불러올 수 없습니다.</p>
+          <button
+            className='mt-3 text-sm font-medium text-orange-500 hover:text-orange-600'
+            type='button'
+            onClick={() => window.location.reload()}
+          >
+            다시 시도
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className='mx-auto w-full max-w-md px-4 py-8 md:py-12'>
+      {/* 페이지 제목 */}
+      <h1 className='mb-6 text-xl font-bold text-gray-900 md:text-2xl'>
+        마이페이지
+      </h1>
+
+      {/* 프로필 카드 */}
+      <div className='space-y-4'>
+        <MyPageProfile user={myInfo} />
+
+        {/* 닉네임 수정 */}
+        <EditNicknameForm currentNickname={myInfo.nickname} />
+
+        {/* 비밀번호 변경 */}
+        <ChangePasswordForm />
+
+        {/* 구분선 */}
+        <div className='my-2' />
+
+        {/* 로그아웃 / 회원 탈퇴 */}
+        <AccountActions />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/my/page.tsx
+++ b/apps/web/src/app/my/page.tsx
@@ -18,9 +18,13 @@ type TabType = 'profile' | 'reviews' | 'wishlist' | 'settings';
 export default function MyPage() {
   const router = useRouter();
   const { isLoggedIn } = useAuthStore();
-  const { data: myInfo, isLoading, error } = useMyInfoQuery();
   const [activeTab, setActiveTab] = useState<TabType>('profile');
   const [mounted, setMounted] = useState(false);
+  const {
+    data: myInfo,
+    isLoading,
+    error,
+  } = useMyInfoQuery(mounted && isLoggedIn);
 
   // hydration 완료 대기 (Zustand persist가 sessionStorage에서 복원 후)
   useEffect(() => {

--- a/apps/web/src/app/my/page.tsx
+++ b/apps/web/src/app/my/page.tsx
@@ -18,15 +18,31 @@ export default function MyPage() {
   const { isLoggedIn } = useAuthStore();
   const { data: myInfo, isLoading, error } = useMyInfoQuery();
   const [activeTab, setActiveTab] = useState<TabType>('profile');
+  const [mounted, setMounted] = useState(false);
 
-  // 비로그인 시 로그인 페이지로 리다이렉트
+  // hydration 완료 대기 (Zustand persist가 sessionStorage에서 복원 후)
   useEffect(() => {
-    if (!isLoggedIn) {
+    setMounted(true);
+  }, []);
+
+  // hydration 완료 후 비로그인 시 리다이렉트
+  useEffect(() => {
+    if (mounted && !isLoggedIn) {
       router.replace('/login');
     }
-  }, [isLoggedIn, router]);
+  }, [mounted, isLoggedIn, router]);
 
-  if (!isLoggedIn) return null;
+  // hydration 전이거나 비로그인이면 로딩 표시
+  if (!mounted || !isLoggedIn) {
+    return (
+      <div className='mx-auto flex min-h-[60vh] max-w-5xl items-center justify-center'>
+        <div className='flex flex-col items-center gap-3'>
+          <div className='h-8 w-8 animate-spin rounded-full border-2 border-orange-400 border-t-transparent' />
+          <p className='text-sm text-gray-400'>불러오는 중...</p>
+        </div>
+      </div>
+    );
+  }
 
   if (isLoading) {
     return (

--- a/apps/web/src/app/places/[id]/page.tsx
+++ b/apps/web/src/app/places/[id]/page.tsx
@@ -33,6 +33,19 @@ export default function PlaceDetailPage() {
   const queryClient = useQueryClient();
   const { addToast } = useToastStore();
 
+  if (Number.isNaN(placeId) || placeId <= 0) {
+    return (
+      <div className='flex h-full min-h-[50vh] flex-col items-center justify-center p-6'>
+        <p className='text-lg font-semibold text-gray-700'>
+          잘못된 접근입니다.
+        </p>
+        <p className='mt-2 text-sm text-gray-500'>
+          장소 정보를 찾을 수 없습니다.
+        </p>
+      </div>
+    );
+  }
+
   const handleLikeToggle = async () => {
     if (!data || !data.placeInfo) return;
 

--- a/apps/web/src/app/places/[id]/page.tsx
+++ b/apps/web/src/app/places/[id]/page.tsx
@@ -43,7 +43,7 @@ export default function PlaceDetailPage() {
     try {
       if (previousState) {
         await unlikePlace(data.placeInfo.id);
-        addToast('찜 목록에서 제외되었습니다.', 'success');
+        addToast('찜 목록에서 제외되었습니다.', 'default');
       } else {
         await likePlace(data.placeInfo.id);
         addToast('찜 목록에 추가되었습니다.', 'success');

--- a/apps/web/src/app/places/[id]/page.tsx
+++ b/apps/web/src/app/places/[id]/page.tsx
@@ -5,8 +5,8 @@ import Image from 'next/image';
 import { useParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
-import { getPlaceDetail, likePlace, unlikePlace } from '@/api/place';
-import { PlaceDetail } from '@/types/place';
+import { likePlace, unlikePlace } from '@/api/place';
+import { usePlaceDetailQuery } from '@/hooks/queries/usePlaceQuery';
 import { resolveThumbnailPath } from '@/utils/petMapper';
 
 import { PlaceDetailHeader } from './components/PlaceDetailHeader';
@@ -16,46 +16,25 @@ import { PlaceReviews } from './components/PlaceReviews';
 
 export default function PlaceDetailPage() {
   const params = useParams();
-  const [data, setData] = useState<PlaceDetail | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const idString = Array.isArray(params.id) ? params.id[0] : params.id;
+  const placeId = parseInt(idString || '', 10);
+
+  const { data, isLoading: loading, error } = usePlaceDetailQuery(placeId);
+
+  // Optimistic UI update를 위한 로컬 상태 유지
   const [isLiked, setIsLiked] = useState(false);
 
+  // 데이터가 로드되거나 변경될 때마다 로컬 상태 동기화
   useEffect(() => {
-    const fetchDetail = async () => {
-      try {
-        const idString = Array.isArray(params.id) ? params.id[0] : params.id;
-        if (!idString) {
-          setError('잘못된 장소 ID입니다.');
-          setLoading(false);
-          return;
-        }
-
-        const placeId = parseInt(idString, 10);
-        if (isNaN(placeId)) throw new Error('Invalid Place ID');
-
-        const result = await getPlaceDetail(placeId);
-
-        if (!result || !result.placeInfo) {
-          throw new Error('No Data');
-        }
-
-        setData(result);
-        setIsLiked(!!result.placeInfo.isLiked);
-      } catch (err) {
-        console.error(err);
-        setError('장소 정보를 불러오는데 실패했습니다.');
-      } finally {
-        setLoading(false);
-      }
-    };
-    fetchDetail();
-  }, [params.id]);
+    if (data?.placeInfo) {
+      setIsLiked(!!data.placeInfo.isLiked);
+    }
+  }, [data?.placeInfo?.isLiked, data?.placeInfo]);
 
   const queryClient = useQueryClient();
 
   const handleLikeToggle = async () => {
-    if (!data) return;
+    if (!data || !data.placeInfo) return;
 
     // Optimistic UI update
     const previousState = isLiked;
@@ -67,7 +46,11 @@ export default function PlaceDetailPage() {
       } else {
         await likePlace(data.placeInfo.id);
       }
-      // 찜 목록 캐시 무효화 (마이페이지 찜 탭 최신화)
+
+      // 장소 상세 정보 캐시 무효화 (해당 장소) 및 찜 목록 무효화
+      queryClient.invalidateQueries({
+        queryKey: ['places', 'detail', data.placeInfo.id],
+      });
       queryClient.invalidateQueries({ queryKey: ['user', 'likedPlaces'] });
     } catch (error) {
       console.error('Failed to toggle like:', error);
@@ -84,10 +67,10 @@ export default function PlaceDetailPage() {
     );
   }
 
-  if (error || !data) {
+  if (error || !data || !data.placeInfo) {
     return (
       <div className='flex min-h-screen items-center justify-center text-gray-500'>
-        {error || '장소를 찾을 수 없습니다.'}
+        {error ? error.message : '장소를 찾을 수 없습니다.'}
       </div>
     );
   }

--- a/apps/web/src/app/places/[id]/page.tsx
+++ b/apps/web/src/app/places/[id]/page.tsx
@@ -3,10 +3,11 @@
 import { useQueryClient } from '@tanstack/react-query';
 import Image from 'next/image';
 import { useParams } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import { likePlace, unlikePlace } from '@/api/place';
 import { usePlaceDetailQuery } from '@/hooks/queries/usePlaceQuery';
+import { useLikedPlaceIdsQuery } from '@/hooks/queries/useUserQuery';
 import { resolveThumbnailPath } from '@/utils/petMapper';
 
 import { PlaceDetailHeader } from './components/PlaceDetailHeader';
@@ -20,16 +21,13 @@ export default function PlaceDetailPage() {
   const placeId = parseInt(idString || '', 10);
 
   const { data, isLoading: loading, error } = usePlaceDetailQuery(placeId);
+  const { data: likedPlaceIds } = useLikedPlaceIdsQuery();
 
-  // Optimistic UI update를 위한 로컬 상태 유지
-  const [isLiked, setIsLiked] = useState(false);
+  // 서버 데이터 우선, 없으면 Optimistic UI 상태
+  const isServerLiked = likedPlaceIds?.includes(placeId) ?? false;
+  const [optimisticLiked, setOptimisticLiked] = useState<boolean | null>(null);
 
-  // 데이터가 로드되거나 변경될 때마다 로컬 상태 동기화
-  useEffect(() => {
-    if (data?.placeInfo) {
-      setIsLiked(!!data.placeInfo.isLiked);
-    }
-  }, [data?.placeInfo?.isLiked, data?.placeInfo]);
+  const isLiked = optimisticLiked !== null ? optimisticLiked : isServerLiked;
 
   const queryClient = useQueryClient();
 
@@ -38,7 +36,7 @@ export default function PlaceDetailPage() {
 
     // Optimistic UI update
     const previousState = isLiked;
-    setIsLiked(!previousState);
+    setOptimisticLiked(!previousState);
 
     try {
       if (previousState) {
@@ -47,15 +45,19 @@ export default function PlaceDetailPage() {
         await likePlace(data.placeInfo.id);
       }
 
-      // 장소 상세 정보 캐시 무효화 (해당 장소) 및 찜 목록 무효화
+      // 장소 상세 정보 캐시 무효화 (해당 장소) 및 찜 목록 아이디 캐시 무효화
+      queryClient.invalidateQueries({ queryKey: ['user', 'likedPlaceIds'] });
+      queryClient.invalidateQueries({ queryKey: ['user', 'likedPlaces'] });
       queryClient.invalidateQueries({
         queryKey: ['places', 'detail', data.placeInfo.id],
       });
-      queryClient.invalidateQueries({ queryKey: ['user', 'likedPlaces'] });
+
+      // 실제 API 반영 완료되면 Optimistic 상태 해제 (서버 데이터 사용)
+      setOptimisticLiked(null);
     } catch (error) {
       console.error('Failed to toggle like:', error);
       // Revert on error
-      setIsLiked(previousState);
+      setOptimisticLiked(previousState);
     }
   };
 

--- a/apps/web/src/app/places/[id]/page.tsx
+++ b/apps/web/src/app/places/[id]/page.tsx
@@ -48,7 +48,15 @@ export default function PlaceDetailPage() {
         await likePlace(data.placeInfo.id);
         addToast('찜 목록에 추가되었습니다.', 'success');
       }
+    } catch (error) {
+      console.error('Failed to toggle like:', error);
+      // Revert on error
+      setOptimisticLiked(previousState);
+      addToast('요청에 실패했습니다. 다시 시도해주세요.', 'error');
+      return;
+    }
 
+    try {
       // 장소 상세 정보 캐시 무효화 (해당 장소) 및 찜 목록 아이디 캐시 무효화
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ['user', 'likedPlaceIds'] }),
@@ -57,14 +65,11 @@ export default function PlaceDetailPage() {
           queryKey: ['places', 'detail', data.placeInfo.id],
         }),
       ]);
-
-      // 실제 API 데이터 페칭 완료 후에 Optimistic 상태 해제 (Blink 방지)
+    } catch (refetchError) {
+      console.error('Failed to refetch queries:', refetchError);
+    } finally {
+      // 실제 API 데이터 페칭 완료(또는 에러) 후에 Optimistic 상태 해제 (Blink 방지)
       setOptimisticLiked(null);
-    } catch (error) {
-      console.error('Failed to toggle like:', error);
-      // Revert on error
-      setOptimisticLiked(previousState);
-      addToast('요청에 실패했습니다. 다시 시도해주세요.', 'error');
     }
   };
 

--- a/apps/web/src/app/places/[id]/page.tsx
+++ b/apps/web/src/app/places/[id]/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useQueryClient } from '@tanstack/react-query';
 import Image from 'next/image';
 import { useParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
@@ -51,6 +52,8 @@ export default function PlaceDetailPage() {
     fetchDetail();
   }, [params.id]);
 
+  const queryClient = useQueryClient();
+
   const handleLikeToggle = async () => {
     if (!data) return;
 
@@ -64,6 +67,8 @@ export default function PlaceDetailPage() {
       } else {
         await likePlace(data.placeInfo.id);
       }
+      // 찜 목록 캐시 무효화 (마이페이지 찜 탭 최신화)
+      queryClient.invalidateQueries({ queryKey: ['user', 'likedPlaces'] });
     } catch (error) {
       console.error('Failed to toggle like:', error);
       // Revert on error

--- a/apps/web/src/app/places/[id]/page.tsx
+++ b/apps/web/src/app/places/[id]/page.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { useQueryClient } from '@tanstack/react-query';
 import Image from 'next/image';
 import { useParams } from 'next/navigation';
 import { useState } from 'react';
 
-import { likePlace, unlikePlace } from '@/api/place';
-import { usePlaceDetailQuery } from '@/hooks/queries/usePlaceQuery';
+import {
+  useLikeToggleMutation,
+  usePlaceDetailQuery,
+} from '@/hooks/queries/usePlaceQuery';
 import { useLikedPlaceIdsQuery } from '@/hooks/queries/useUserQuery';
 import { useToastStore } from '@/stores/useToastStore';
 import { resolveThumbnailPath } from '@/utils/petMapper';
@@ -23,15 +24,15 @@ export default function PlaceDetailPage() {
 
   const { data, isLoading: loading, error } = usePlaceDetailQuery(placeId);
   const { data: likedPlaceIds } = useLikedPlaceIdsQuery();
+  const { addToast } = useToastStore();
 
   // 서버 데이터 우선, 없으면 Optimistic UI 상태
   const isServerLiked = likedPlaceIds?.includes(placeId) ?? false;
   const [optimisticLiked, setOptimisticLiked] = useState<boolean | null>(null);
-
   const isLiked = optimisticLiked !== null ? optimisticLiked : isServerLiked;
 
-  const queryClient = useQueryClient();
-  const { addToast } = useToastStore();
+  const { mutate: toggleLike, isPending: isLikeToggling } =
+    useLikeToggleMutation();
 
   if (Number.isNaN(placeId) || placeId <= 0) {
     return (
@@ -46,44 +47,32 @@ export default function PlaceDetailPage() {
     );
   }
 
-  const handleLikeToggle = async () => {
-    if (!data || !data.placeInfo) return;
+  const handleLikeToggle = () => {
+    if (!data?.placeInfo || isLikeToggling) return;
 
-    // Optimistic UI update
     const previousState = isLiked;
     setOptimisticLiked(!previousState);
 
-    try {
-      if (previousState) {
-        await unlikePlace(data.placeInfo.id);
-        addToast('찜 목록에서 제외되었습니다.', 'default');
-      } else {
-        await likePlace(data.placeInfo.id);
-        addToast('찜 목록에 추가되었습니다.', 'success');
-      }
-    } catch (error) {
-      console.error('Failed to toggle like:', error);
-      // Revert on error
-      setOptimisticLiked(previousState);
-      addToast('요청에 실패했습니다. 다시 시도해주세요.', 'error');
-      return;
-    }
-
-    try {
-      // 장소 상세 정보 캐시 무효화 (해당 장소) 및 찜 목록 아이디 캐시 무효화
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ['user', 'likedPlaceIds'] }),
-        queryClient.invalidateQueries({ queryKey: ['user', 'likedPlaces'] }),
-        queryClient.invalidateQueries({
-          queryKey: ['places', 'detail', data.placeInfo.id],
-        }),
-      ]);
-    } catch (refetchError) {
-      console.error('Failed to refetch queries:', refetchError);
-    } finally {
-      // 실제 API 데이터 페칭 완료(또는 에러) 후에 Optimistic 상태 해제 (Blink 방지)
-      setOptimisticLiked(null);
-    }
+    toggleLike(
+      { placeId: data.placeInfo.id, isCurrentlyLiked: previousState },
+      {
+        onSuccess: () => {
+          addToast(
+            previousState
+              ? '찜 목록에서 제외되었습니다.'
+              : '찜 목록에 추가되었습니다.',
+            previousState ? 'default' : 'success',
+          );
+        },
+        onError: () => {
+          setOptimisticLiked(previousState);
+          addToast('요청에 실패했습니다. 다시 시도해주세요.', 'error');
+        },
+        onSettled: () => {
+          setOptimisticLiked(null);
+        },
+      },
+    );
   };
 
   if (loading) {

--- a/apps/web/src/app/places/[id]/page.tsx
+++ b/apps/web/src/app/places/[id]/page.tsx
@@ -8,6 +8,7 @@ import { useState } from 'react';
 import { likePlace, unlikePlace } from '@/api/place';
 import { usePlaceDetailQuery } from '@/hooks/queries/usePlaceQuery';
 import { useLikedPlaceIdsQuery } from '@/hooks/queries/useUserQuery';
+import { useToastStore } from '@/stores/useToastStore';
 import { resolveThumbnailPath } from '@/utils/petMapper';
 
 import { PlaceDetailHeader } from './components/PlaceDetailHeader';
@@ -30,6 +31,7 @@ export default function PlaceDetailPage() {
   const isLiked = optimisticLiked !== null ? optimisticLiked : isServerLiked;
 
   const queryClient = useQueryClient();
+  const { addToast } = useToastStore();
 
   const handleLikeToggle = async () => {
     if (!data || !data.placeInfo) return;
@@ -41,23 +43,28 @@ export default function PlaceDetailPage() {
     try {
       if (previousState) {
         await unlikePlace(data.placeInfo.id);
+        addToast('찜 목록에서 제외되었습니다.', 'success');
       } else {
         await likePlace(data.placeInfo.id);
+        addToast('찜 목록에 추가되었습니다.', 'success');
       }
 
       // 장소 상세 정보 캐시 무효화 (해당 장소) 및 찜 목록 아이디 캐시 무효화
-      queryClient.invalidateQueries({ queryKey: ['user', 'likedPlaceIds'] });
-      queryClient.invalidateQueries({ queryKey: ['user', 'likedPlaces'] });
-      queryClient.invalidateQueries({
-        queryKey: ['places', 'detail', data.placeInfo.id],
-      });
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['user', 'likedPlaceIds'] }),
+        queryClient.invalidateQueries({ queryKey: ['user', 'likedPlaces'] }),
+        queryClient.invalidateQueries({
+          queryKey: ['places', 'detail', data.placeInfo.id],
+        }),
+      ]);
 
-      // 실제 API 반영 완료되면 Optimistic 상태 해제 (서버 데이터 사용)
+      // 실제 API 데이터 페칭 완료 후에 Optimistic 상태 해제 (Blink 방지)
       setOptimisticLiked(null);
     } catch (error) {
       console.error('Failed to toggle like:', error);
       // Revert on error
       setOptimisticLiked(previousState);
+      addToast('요청에 실패했습니다. 다시 시도해주세요.', 'error');
     }
   };
 

--- a/apps/web/src/hooks/queries/useAuthMutation.ts
+++ b/apps/web/src/hooks/queries/useAuthMutation.ts
@@ -101,6 +101,7 @@ export const useLogoutMutation = ({
     onSuccess: () => {
       // 로그아웃 성공 시 로컬스토리지의 토큰 제거
       if (typeof window !== 'undefined') {
+        localStorage.removeItem(CONSTANTS.STORAGE_KEYS.AUTH_TOKEN);
         localStorage.removeItem('accessToken');
       }
       onSuccess?.();

--- a/apps/web/src/hooks/queries/useAuthMutation.ts
+++ b/apps/web/src/hooks/queries/useAuthMutation.ts
@@ -99,6 +99,10 @@ export const useLogoutMutation = ({
   return useMutation({
     mutationFn: logout,
     onSuccess: () => {
+      // 로그아웃 성공 시 로컬스토리지의 토큰 제거
+      if (typeof window !== 'undefined') {
+        localStorage.removeItem('accessToken');
+      }
       onSuccess?.();
     },
     onError,

--- a/apps/web/src/hooks/queries/useAuthMutation.ts
+++ b/apps/web/src/hooks/queries/useAuthMutation.ts
@@ -99,14 +99,17 @@ export const useLogoutMutation = ({
   return useMutation({
     mutationFn: logout,
     onSuccess: () => {
-      // 로그아웃 성공 시 로컬스토리지의 토큰 제거
+      // API 성공 후 실행될 콜백
+      onSuccess?.();
+    },
+    onError,
+    onSettled: () => {
+      // API 요청의 성공/실패 여부와 관계없이 토큰 제거 처리
       if (typeof window !== 'undefined') {
         localStorage.removeItem(CONSTANTS.STORAGE_KEYS.AUTH_TOKEN);
         localStorage.removeItem(CONSTANTS.STORAGE_KEYS.REFRESH_TOKEN);
         localStorage.removeItem('accessToken');
       }
-      onSuccess?.();
     },
-    onError,
   });
 };

--- a/apps/web/src/hooks/queries/useAuthMutation.ts
+++ b/apps/web/src/hooks/queries/useAuthMutation.ts
@@ -3,7 +3,7 @@
 import { CONSTANTS } from '@shared/config/constants';
 import { useMutation } from '@tanstack/react-query';
 
-import { checkEmail, checkNickname, login, signup } from '@/api/auth';
+import { checkEmail, checkNickname, login, logout, signup } from '@/api/auth';
 import { LoginRequest, SignupRequest } from '@/types/auth';
 
 interface UseSignupMutationProps {
@@ -11,6 +11,7 @@ interface UseSignupMutationProps {
   onError?: (error: unknown) => void;
 }
 
+// ─── 회원가입 ───
 export const useSignupMutation = ({
   onSuccess,
   onError,
@@ -35,6 +36,7 @@ interface UseLoginMutationProps {
   onError?: (error: unknown) => void;
 }
 
+// ─── 로그인 ───
 export const useLoginMutation = ({
   onSuccess,
   onError,
@@ -70,14 +72,35 @@ export const useLoginMutation = ({
   });
 };
 
+// ─── 이메일 중복 확인 ───
 export const useCheckEmailMutation = () => {
   return useMutation({
     mutationFn: checkEmail,
   });
 };
 
+// ─── 닉네임 중복 확인 ───
 export const useCheckNicknameMutation = () => {
   return useMutation({
     mutationFn: checkNickname,
+  });
+};
+
+// ─── 로그아웃 ───
+interface UseLogoutMutationProps {
+  onSuccess?: () => void;
+  onError?: (error: unknown) => void;
+}
+
+export const useLogoutMutation = ({
+  onSuccess,
+  onError,
+}: UseLogoutMutationProps = {}) => {
+  return useMutation({
+    mutationFn: logout,
+    onSuccess: () => {
+      onSuccess?.();
+    },
+    onError,
   });
 };

--- a/apps/web/src/hooks/queries/useAuthMutation.ts
+++ b/apps/web/src/hooks/queries/useAuthMutation.ts
@@ -102,6 +102,7 @@ export const useLogoutMutation = ({
       // 로그아웃 성공 시 로컬스토리지의 토큰 제거
       if (typeof window !== 'undefined') {
         localStorage.removeItem(CONSTANTS.STORAGE_KEYS.AUTH_TOKEN);
+        localStorage.removeItem(CONSTANTS.STORAGE_KEYS.REFRESH_TOKEN);
         localStorage.removeItem('accessToken');
       }
       onSuccess?.();

--- a/apps/web/src/hooks/queries/usePlaceQuery.ts
+++ b/apps/web/src/hooks/queries/usePlaceQuery.ts
@@ -17,7 +17,7 @@ export const usePlaceDetailQuery = (placeId: number) => {
   return useQuery({
     queryKey: placeKeys.detail(placeId),
     queryFn: () => getPlaceDetail(placeId),
-    enabled: !!placeId,
+    enabled: placeId > 0 && !Number.isNaN(placeId),
     staleTime: 1000 * 60 * 5, // 5분
   });
 };

--- a/apps/web/src/hooks/queries/usePlaceQuery.ts
+++ b/apps/web/src/hooks/queries/usePlaceQuery.ts
@@ -1,0 +1,23 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getPlaceDetail } from '@/api/place';
+
+export const placeKeys = {
+  all: ['places'] as const,
+  lists: () => [...placeKeys.all, 'list'] as const,
+  list: (filters: string) => [...placeKeys.lists(), { filters }] as const,
+  details: () => [...placeKeys.all, 'detail'] as const,
+  detail: (id: number) => [...placeKeys.details(), id] as const,
+  random: () => [...placeKeys.all, 'random'] as const,
+  reviews: (id: number) => [...placeKeys.all, 'reviews', id] as const,
+};
+
+// 장소 상세 조회
+export const usePlaceDetailQuery = (placeId: number) => {
+  return useQuery({
+    queryKey: placeKeys.detail(placeId),
+    queryFn: () => getPlaceDetail(placeId),
+    enabled: !!placeId,
+    staleTime: 1000 * 60 * 5, // 5분
+  });
+};

--- a/apps/web/src/hooks/queries/usePlaceQuery.ts
+++ b/apps/web/src/hooks/queries/usePlaceQuery.ts
@@ -1,6 +1,6 @@
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-import { getPlaceDetail } from '@/api/place';
+import { getPlaceDetail, likePlace, unlikePlace } from '@/api/place';
 
 export const placeKeys = {
   all: ['places'] as const,
@@ -19,5 +19,26 @@ export const usePlaceDetailQuery = (placeId: number) => {
     queryFn: () => getPlaceDetail(placeId),
     enabled: placeId > 0 && !Number.isNaN(placeId),
     staleTime: 1000 * 60 * 5, // 5분
+  });
+};
+
+// ─── 찜 토글 Mutation ───
+interface LikeToggleParams {
+  placeId: number;
+  isCurrentlyLiked: boolean;
+}
+
+export const useLikeToggleMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ placeId, isCurrentlyLiked }: LikeToggleParams) =>
+      isCurrentlyLiked ? unlikePlace(placeId) : likePlace(placeId),
+    onSettled: (_data, _error, { placeId }) => {
+      // 성공/실패 무관하게 관련 캐시 갱신
+      queryClient.invalidateQueries({ queryKey: ['user', 'likedPlaceIds'] });
+      queryClient.invalidateQueries({ queryKey: ['user', 'likedPlaces'] });
+      queryClient.invalidateQueries({ queryKey: placeKeys.detail(placeId) });
+    },
   });
 };

--- a/apps/web/src/hooks/queries/useUserQuery.ts
+++ b/apps/web/src/hooks/queries/useUserQuery.ts
@@ -102,7 +102,13 @@ export const useLikedPlaceIdsQuery = () => {
 
 // ─── 찜 목록 조회 (/users/likes → 장소 상세 조회) ───
 export const useLikedPlacesQuery = () => {
-  const { data: placeIds, isLoading: isIdsLoading } = useLikedPlaceIdsQuery();
+  const {
+    data: placeIds,
+    isLoading: isIdsLoading,
+    isError: isIdsError,
+    error: idsError,
+    refetch: refetchIds,
+  } = useLikedPlaceIdsQuery();
 
   const query = useQuery({
     queryKey: [
@@ -125,13 +131,24 @@ export const useLikedPlacesQuery = () => {
       );
       return results.filter((r): r is NonNullable<typeof r> => r !== null);
     },
-    enabled: !!placeIds, // placeIds가 로딩 완료된 후에만 실행
+    enabled: !!placeIds && !isIdsError, // placeIds가 로딩 완료된 후에만 실행
     staleTime: 1000 * 60 * 3,
   });
 
   return {
     ...query,
     isLoading: isIdsLoading || query.isLoading,
+    isError: isIdsError || query.isError,
+    error: idsError || query.error,
+    refetch: async (options?: any) => {
+      if (isIdsError || !placeIds) {
+        const idResult = await refetchIds(options);
+        if (idResult.isError) {
+          return idResult as any;
+        }
+      }
+      return query.refetch(options);
+    },
   };
 };
 

--- a/apps/web/src/hooks/queries/useUserQuery.ts
+++ b/apps/web/src/hooks/queries/useUserQuery.ts
@@ -93,13 +93,23 @@ export const useMyReviewsQuery = (page = 0, size = 5) => {
   });
 };
 
+// ─── 찜한 장소 ID 목록만 단독 조회 ───
+export const useLikedPlaceIdsQuery = () => {
+  return useQuery({
+    queryKey: [...userKeys.all, 'likedPlaceIds'] as const,
+    queryFn: getMyLikedPlaceIds,
+    staleTime: 1000 * 60 * 3,
+  });
+};
+
 // ─── 찜 목록 조회 (/users/likes → 장소 상세 조회) ───
 export const useLikedPlacesQuery = () => {
+  const { data: placeIds } = useLikedPlaceIdsQuery();
+
   return useQuery({
     queryKey: [...userKeys.all, 'likedPlaces'] as const,
     queryFn: async () => {
-      const placeIds = await getMyLikedPlaceIds();
-      if (!placeIds.length) return [];
+      if (!placeIds || !placeIds.length) return [];
       const results = await Promise.all(
         placeIds.map((id) => getPlaceDetail(id).catch(() => null)),
       );

--- a/apps/web/src/hooks/queries/useUserQuery.ts
+++ b/apps/web/src/hooks/queries/useUserQuery.ts
@@ -1,0 +1,94 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { logout } from '@/api/auth';
+import {
+  changePassword,
+  deleteUser,
+  getMyInfo,
+  updateMyInfo,
+} from '@/api/user';
+import { ChangePasswordRequest, UpdateUserRequest } from '@/types/user';
+
+// ─── Query Keys ───
+const userKeys = {
+  all: ['user'] as const,
+  myInfo: () => [...userKeys.all, 'myInfo'] as const,
+};
+
+// ─── 내 정보 조회 ───
+export const useMyInfoQuery = () => {
+  return useQuery({
+    queryKey: userKeys.myInfo(),
+    queryFn: async () => {
+      const response = await getMyInfo();
+      return response.data;
+    },
+    staleTime: 1000 * 60 * 5, // 5분
+  });
+};
+
+// ─── 닉네임 수정 ───
+interface UseMutationCallbacks {
+  onSuccess?: () => void;
+  onError?: (error: unknown) => void;
+}
+
+export const useUpdateNicknameMutation = ({
+  onSuccess,
+  onError,
+}: UseMutationCallbacks = {}) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: UpdateUserRequest) => updateMyInfo(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: userKeys.myInfo() });
+      onSuccess?.();
+    },
+    onError,
+  });
+};
+
+// ─── 비밀번호 변경 ───
+export const useChangePasswordMutation = ({
+  onSuccess,
+  onError,
+}: UseMutationCallbacks = {}) => {
+  return useMutation({
+    mutationFn: (data: ChangePasswordRequest) => changePassword(data),
+    onSuccess: () => {
+      onSuccess?.();
+    },
+    onError,
+  });
+};
+
+// ─── 로그아웃 ───
+export const useLogoutMutation = ({
+  onSuccess,
+  onError,
+}: UseMutationCallbacks = {}) => {
+  return useMutation({
+    mutationFn: logout,
+    onSuccess: () => {
+      onSuccess?.();
+    },
+    onError,
+  });
+};
+
+// ─── 회원 탈퇴 ───
+export const useDeleteAccountMutation = ({
+  onSuccess,
+  onError,
+}: UseMutationCallbacks = {}) => {
+  return useMutation({
+    mutationFn: deleteUser,
+    onSuccess: () => {
+      onSuccess?.();
+    },
+    onError,
+  });
+};

--- a/apps/web/src/hooks/queries/useUserQuery.ts
+++ b/apps/web/src/hooks/queries/useUserQuery.ts
@@ -125,7 +125,7 @@ export const useLikedPlacesQuery = () => {
           }),
         ),
       );
-      return results.filter(Boolean);
+      return results.filter((r): r is NonNullable<typeof r> => r !== null);
     },
     enabled: !!placeIds, // placeIds가 로딩 완료된 후에만 실행
     staleTime: 1000 * 60 * 3,

--- a/apps/web/src/hooks/queries/useUserQuery.ts
+++ b/apps/web/src/hooks/queries/useUserQuery.ts
@@ -2,6 +2,8 @@
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
+import { getPlaceDetail } from '@/api/place';
+import { deleteReview, getMyReviews } from '@/api/review';
 import {
   changePassword,
   deleteUser,
@@ -72,6 +74,59 @@ export const useDeleteAccountMutation = ({
   return useMutation({
     mutationFn: deleteUser,
     onSuccess: () => {
+      onSuccess?.();
+    },
+    onError,
+  });
+};
+
+// ─── 내 리뷰 목록 조회 ───
+export const useMyReviewsQuery = (page = 0, size = 5) => {
+  return useQuery({
+    queryKey: [...userKeys.all, 'myReviews', page, size] as const,
+    queryFn: async () => {
+      const response = await getMyReviews(page, size);
+      return response.data;
+    },
+    staleTime: 1000 * 60 * 3, // 3분
+  });
+};
+
+// ─── 찜 목록 조회 (likedPlaceIds 기반) ───
+export const useLikedPlacesQuery = (placeIds: number[]) => {
+  return useQuery({
+    queryKey: [...userKeys.all, 'likedPlaces', placeIds] as const,
+    queryFn: async () => {
+      if (!placeIds.length) return [];
+      const results = await Promise.all(
+        placeIds.map((id) => getPlaceDetail(id).catch(() => null)),
+      );
+      return results.filter(Boolean);
+    },
+    enabled: placeIds.length > 0,
+    staleTime: 1000 * 60 * 5,
+  });
+};
+
+// ─── 리뷰 삭제 ───
+export const useDeleteReviewMutation = ({
+  onSuccess,
+  onError,
+}: UseMutationCallbacks = {}) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      placeId,
+      reviewId,
+    }: {
+      placeId: number;
+      reviewId: number;
+    }) => deleteReview(placeId, reviewId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [...userKeys.all, 'myReviews'],
+      });
       onSuccess?.();
     },
     onError,

--- a/apps/web/src/hooks/queries/useUserQuery.ts
+++ b/apps/web/src/hooks/queries/useUserQuery.ts
@@ -8,6 +8,7 @@ import {
   changePassword,
   deleteUser,
   getMyInfo,
+  getMyLikedPlaceIds,
   updateMyInfo,
 } from '@/api/user';
 import { ChangePasswordRequest, UpdateUserRequest } from '@/types/user';
@@ -92,19 +93,19 @@ export const useMyReviewsQuery = (page = 0, size = 5) => {
   });
 };
 
-// ─── 찜 목록 조회 (likedPlaceIds 기반) ───
-export const useLikedPlacesQuery = (placeIds: number[]) => {
+// ─── 찜 목록 조회 (/users/likes → 장소 상세 조회) ───
+export const useLikedPlacesQuery = () => {
   return useQuery({
-    queryKey: [...userKeys.all, 'likedPlaces', placeIds] as const,
+    queryKey: [...userKeys.all, 'likedPlaces'] as const,
     queryFn: async () => {
+      const placeIds = await getMyLikedPlaceIds();
       if (!placeIds.length) return [];
       const results = await Promise.all(
         placeIds.map((id) => getPlaceDetail(id).catch(() => null)),
       );
       return results.filter(Boolean);
     },
-    enabled: placeIds.length > 0,
-    staleTime: 1000 * 60 * 5,
+    staleTime: 1000 * 60 * 3,
   });
 };
 

--- a/apps/web/src/hooks/queries/useUserQuery.ts
+++ b/apps/web/src/hooks/queries/useUserQuery.ts
@@ -2,7 +2,6 @@
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-import { logout } from '@/api/auth';
 import {
   changePassword,
   deleteUser,
@@ -58,20 +57,6 @@ export const useChangePasswordMutation = ({
 }: UseMutationCallbacks = {}) => {
   return useMutation({
     mutationFn: (data: ChangePasswordRequest) => changePassword(data),
-    onSuccess: () => {
-      onSuccess?.();
-    },
-    onError,
-  });
-};
-
-// ─── 로그아웃 ───
-export const useLogoutMutation = ({
-  onSuccess,
-  onError,
-}: UseMutationCallbacks = {}) => {
-  return useMutation({
-    mutationFn: logout,
     onSuccess: () => {
       onSuccess?.();
     },

--- a/apps/web/src/hooks/queries/useUserQuery.ts
+++ b/apps/web/src/hooks/queries/useUserQuery.ts
@@ -20,7 +20,7 @@ export const userKeys = {
 };
 
 // ─── 내 정보 조회 ───
-export const useMyInfoQuery = () => {
+export const useMyInfoQuery = (enabled = true) => {
   return useQuery({
     queryKey: userKeys.myInfo(),
     queryFn: async () => {
@@ -28,6 +28,7 @@ export const useMyInfoQuery = () => {
       return response.data;
     },
     staleTime: 1000 * 60 * 5, // 5분
+    enabled,
   });
 };
 

--- a/apps/web/src/hooks/queries/useUserQuery.ts
+++ b/apps/web/src/hooks/queries/useUserQuery.ts
@@ -107,7 +107,7 @@ export const useLikedPlacesQuery = () => {
   const { data: placeIds } = useLikedPlaceIdsQuery();
 
   return useQuery({
-    queryKey: [...userKeys.all, 'likedPlaces'] as const,
+    queryKey: [...userKeys.all, 'likedPlaces', placeIds] as const,
     queryFn: async () => {
       if (!placeIds || !placeIds.length) return [];
       const results = await Promise.all(
@@ -115,6 +115,7 @@ export const useLikedPlacesQuery = () => {
       );
       return results.filter(Boolean);
     },
+    enabled: !!placeIds, // placeIds가 로딩 완료된 후에만 실행
     staleTime: 1000 * 60 * 3,
   });
 };

--- a/apps/web/src/hooks/queries/useUserQuery.ts
+++ b/apps/web/src/hooks/queries/useUserQuery.ts
@@ -107,11 +107,23 @@ export const useLikedPlacesQuery = () => {
   const { data: placeIds, isLoading: isIdsLoading } = useLikedPlaceIdsQuery();
 
   const query = useQuery({
-    queryKey: [...userKeys.all, 'likedPlaces', placeIds] as const,
+    queryKey: [
+      ...userKeys.all,
+      'likedPlaces',
+      placeIds ? [...placeIds].sort((a, b) => a - b).join(',') : '',
+    ] as const,
     queryFn: async () => {
       if (!placeIds || !placeIds.length) return [];
       const results = await Promise.all(
-        placeIds.map((id) => getPlaceDetail(id).catch(() => null)),
+        placeIds.map((id) =>
+          getPlaceDetail(id).catch((err) => {
+            console.error(
+              `Failed to fetch liked place detail (ID: ${id}):`,
+              err,
+            );
+            return null;
+          }),
+        ),
       );
       return results.filter(Boolean);
     },

--- a/apps/web/src/hooks/queries/useUserQuery.ts
+++ b/apps/web/src/hooks/queries/useUserQuery.ts
@@ -104,9 +104,9 @@ export const useLikedPlaceIdsQuery = () => {
 
 // ─── 찜 목록 조회 (/users/likes → 장소 상세 조회) ───
 export const useLikedPlacesQuery = () => {
-  const { data: placeIds } = useLikedPlaceIdsQuery();
+  const { data: placeIds, isLoading: isIdsLoading } = useLikedPlaceIdsQuery();
 
-  return useQuery({
+  const query = useQuery({
     queryKey: [...userKeys.all, 'likedPlaces', placeIds] as const,
     queryFn: async () => {
       if (!placeIds || !placeIds.length) return [];
@@ -118,6 +118,11 @@ export const useLikedPlacesQuery = () => {
     enabled: !!placeIds, // placeIds가 로딩 완료된 후에만 실행
     staleTime: 1000 * 60 * 3,
   });
+
+  return {
+    ...query,
+    isLoading: isIdsLoading || query.isLoading,
+  };
 };
 
 // ─── 리뷰 삭제 ───

--- a/apps/web/src/hooks/queries/useUserQuery.ts
+++ b/apps/web/src/hooks/queries/useUserQuery.ts
@@ -14,7 +14,7 @@ import {
 import { ChangePasswordRequest, UpdateUserRequest } from '@/types/user';
 
 // ─── Query Keys ───
-const userKeys = {
+export const userKeys = {
   all: ['user'] as const,
   myInfo: () => [...userKeys.all, 'myInfo'] as const,
 };

--- a/apps/web/src/hooks/queries/useUserQuery.ts
+++ b/apps/web/src/hooks/queries/useUserQuery.ts
@@ -86,10 +86,7 @@ export const useDeleteAccountMutation = ({
 export const useMyReviewsQuery = (page = 0, size = 5) => {
   return useQuery({
     queryKey: [...userKeys.all, 'myReviews', page, size] as const,
-    queryFn: async () => {
-      const response = await getMyReviews(page, size);
-      return response.data;
-    },
+    queryFn: () => getMyReviews(page, size),
     staleTime: 1000 * 60 * 3, // 3분
   });
 };

--- a/apps/web/src/stores/useAuthStore.ts
+++ b/apps/web/src/stores/useAuthStore.ts
@@ -62,6 +62,7 @@ export const useAuthStore = create<AuthState>()(
       storage: createJSONStorage(() => localStorage),
       partialize: (state) => ({
         isLoggedIn: state.isLoggedIn,
+        user: state.user,
       }),
     },
   ),

--- a/apps/web/src/stores/useAuthStore.ts
+++ b/apps/web/src/stores/useAuthStore.ts
@@ -60,6 +60,14 @@ export const useAuthStore = create<AuthState>()(
       name: 'auth-storage',
       // sessionStorage는 탭별로 고립되므로 탭 간 상태 공유를 위해 localStorage 사용
       storage: createJSONStorage(() => localStorage),
+      onRehydrateStorage: () => (state) => {
+        if (typeof window !== 'undefined') {
+          const token = localStorage.getItem(CONSTANTS.STORAGE_KEYS.AUTH_TOKEN);
+          if (!token && state) {
+            state.setLogout();
+          }
+        }
+      },
       partialize: (state) => ({
         isLoggedIn: state.isLoggedIn,
         // PII(개인정보) 유출 방지를 위해 민감한 정보(이메일 등)는 로컬 스토리지에서 마스킹/제거합니다.

--- a/apps/web/src/stores/useAuthStore.ts
+++ b/apps/web/src/stores/useAuthStore.ts
@@ -62,7 +62,13 @@ export const useAuthStore = create<AuthState>()(
       storage: createJSONStorage(() => localStorage),
       partialize: (state) => ({
         isLoggedIn: state.isLoggedIn,
-        user: state.user,
+        // PII(개인정보) 유출 방지를 위해 민감한 정보(이메일 등)는 로컬 스토리지에서 마스킹/제거합니다.
+        user: state.user
+          ? {
+              ...state.user,
+              email: '',
+            }
+          : null,
       }),
     },
   ),

--- a/apps/web/src/stores/useAuthStore.ts
+++ b/apps/web/src/stores/useAuthStore.ts
@@ -58,7 +58,8 @@ export const useAuthStore = create<AuthState>()(
     }),
     {
       name: 'auth-storage',
-      storage: createJSONStorage(() => sessionStorage),
+      // sessionStorage는 탭별로 고립되므로 탭 간 상태 공유를 위해 localStorage 사용
+      storage: createJSONStorage(() => localStorage),
       partialize: (state) => ({
         isLoggedIn: state.isLoggedIn,
       }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
         specifier: ^5.0.9
         version: 5.0.9(@types/react@19.2.0)(react@19.2.3)
     devDependencies:
+      '@next/bundle-analyzer':
+        specifier: ^16.1.6
+        version: 16.1.6
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.1.14
@@ -817,6 +820,10 @@ packages:
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
 
+  '@discoveryjs/json-ext@0.5.7':
+    resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
+    engines: {node: '>=10.0.0'}
+
   '@emnapi/core@1.5.0':
     resolution: {integrity: sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==}
 
@@ -1391,6 +1398,9 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
+  '@next/bundle-analyzer@16.1.6':
+    resolution: {integrity: sha512-ee2kagdTaeEWPlotgdTOqFHYcD3e2m2bbE3I9Rq2i6ABYi5OgopmtEUe8NM23viaYxLV2tDH/2nd5+qKoEr6cw==}
+
   '@next/env@16.0.10':
     resolution: {integrity: sha512-8tuaQkyDVgeONQ1MeT9Mkk8pQmZapMKFh5B+OrFUlG3rVmYTXcXlBetBgTurKXGaIZvkoqRT9JL5K3phXcgang==}
 
@@ -1490,6 +1500,9 @@ packages:
         optional: true
       webpack-plugin-serve:
         optional: true
+
+  '@polka/url@1.0.0-next.29':
+    resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
@@ -2237,6 +2250,10 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
+  acorn-walk@8.3.5:
+    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
+    engines: {node: '>=0.4.0'}
+
   acorn@8.15.0:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
@@ -2696,6 +2713,10 @@ packages:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
 
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+
   commander@8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
     engines: {node: '>= 12'}
@@ -2834,6 +2855,9 @@ packages:
   data-view-byte-offset@1.0.1:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
+
+  debounce@1.2.1:
+    resolution: {integrity: sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==}
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -3554,6 +3578,10 @@ packages:
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
+  gzip-size@6.0.0:
+    resolution: {integrity: sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==}
+    engines: {node: '>=10'}
+
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
@@ -3627,6 +3655,9 @@ packages:
 
   html-entities@2.6.0:
     resolution: {integrity: sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   html-minifier-terser@6.1.0:
     resolution: {integrity: sha512-YXxSlJBZTP7RS3tWnQw74ooKa6L9b9i9QYXY21eUEvhZ3u9XLfv6OnFsQq6RxkhHygsaUMvYsZRV5rU/OVNZxw==}
@@ -3869,6 +3900,10 @@ packages:
 
   is-plain-object@2.0.4:
     resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==}
+    engines: {node: '>=0.10.0'}
+
+  is-plain-object@5.0.0:
+    resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
     engines: {node: '>=0.10.0'}
 
   is-posix-bracket@0.1.1:
@@ -4305,6 +4340,10 @@ packages:
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
 
+  mrmime@2.0.1:
+    resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
+    engines: {node: '>=10'}
+
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
@@ -4460,6 +4499,10 @@ packages:
   open@8.4.2:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
+
+  opener@1.5.2:
+    resolution: {integrity: sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==}
+    hasBin: true
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -5194,6 +5237,10 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  sirv@2.0.4:
+    resolution: {integrity: sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==}
+    engines: {node: '>= 10'}
+
   slice-ansi@7.1.2:
     resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
     engines: {node: '>=18'}
@@ -5506,6 +5553,10 @@ packages:
   to-regex@3.0.2:
     resolution: {integrity: sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==}
     engines: {node: '>=0.10.0'}
+
+  totalist@3.0.1:
+    resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
+    engines: {node: '>=6'}
 
   tough-cookie@4.1.4:
     resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
@@ -5851,6 +5902,11 @@ packages:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
 
+  webpack-bundle-analyzer@4.10.1:
+    resolution: {integrity: sha512-s3P7pgexgT/HTUSYgxJyn28A+99mmLq4HsJepMPzu0R8ImJc52QNqaFYW1Z2z2uIb1/J3eYgaAWVpaC+v/1aAQ==}
+    engines: {node: '>= 10.13.0'}
+    hasBin: true
+
   webpack-dev-middleware@6.1.3:
     resolution: {integrity: sha512-A4ChP0Qj8oGociTs6UdlRUGANIGrCDL3y+pmQMc+dSsraXHCatFpmMey4mYELA+juqwUqwQsUgJJISXl1KWmiw==}
     engines: {node: '>= 14.15.0'}
@@ -5939,6 +5995,18 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@7.5.10:
+    resolution: {integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==}
+    engines: {node: '>=8.3.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   ws@8.18.3:
     resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
@@ -6807,6 +6875,8 @@ snapshots:
 
   '@csstools/css-tokenizer@3.0.4': {}
 
+  '@discoveryjs/json-ext@0.5.7': {}
+
   '@emnapi/core@1.5.0':
     dependencies:
       '@emnapi/wasi-threads': 1.1.0
@@ -7210,6 +7280,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
+  '@next/bundle-analyzer@16.1.6':
+    dependencies:
+      webpack-bundle-analyzer: 4.10.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@next/env@16.0.10': {}
 
   '@next/eslint-plugin-next@16.1.6':
@@ -7271,6 +7348,8 @@ snapshots:
     optionalDependencies:
       type-fest: 2.19.0
       webpack-hot-middleware: 2.26.1
+
+  '@polka/url@1.0.0-next.29': {}
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
@@ -8160,6 +8239,10 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
+  acorn-walk@8.3.5:
+    dependencies:
+      acorn: 8.15.0
+
   acorn@8.15.0: {}
 
   adjust-sourcemap-loader@4.0.0:
@@ -8699,6 +8782,8 @@ snapshots:
 
   commander@4.1.1: {}
 
+  commander@7.2.0: {}
+
   commander@8.3.0: {}
 
   common-path-prefix@3.0.0: {}
@@ -8867,6 +8952,8 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-data-view: 1.0.2
+
+  debounce@1.2.1: {}
 
   debug@2.6.9:
     dependencies:
@@ -9871,6 +9958,10 @@ snapshots:
 
   graphemer@1.4.0: {}
 
+  gzip-size@6.0.0:
+    dependencies:
+      duplexer: 0.1.2
+
   has-bigints@1.1.0: {}
 
   has-flag@4.0.0: {}
@@ -9948,6 +10039,8 @@ snapshots:
       whatwg-encoding: 3.1.1
 
   html-entities@2.6.0: {}
+
+  html-escaper@2.0.2: {}
 
   html-minifier-terser@6.1.0:
     dependencies:
@@ -10184,6 +10277,8 @@ snapshots:
   is-plain-object@2.0.4:
     dependencies:
       isobject: 3.0.1
+
+  is-plain-object@5.0.0: {}
 
   is-posix-bracket@0.1.1: {}
 
@@ -10625,6 +10720,8 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.1
 
+  mrmime@2.0.1: {}
+
   ms@2.0.0: {}
 
   ms@2.1.3: {}
@@ -10843,6 +10940,8 @@ snapshots:
       define-lazy-prop: 2.0.0
       is-docker: 2.2.1
       is-wsl: 2.2.0
+
+  opener@1.5.2: {}
 
   optionator@0.9.4:
     dependencies:
@@ -11593,6 +11692,12 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  sirv@2.0.4:
+    dependencies:
+      '@polka/url': 1.0.0-next.29
+      mrmime: 2.0.1
+      totalist: 3.0.1
+
   slice-ansi@7.1.2:
     dependencies:
       ansi-styles: 6.2.3
@@ -11950,6 +12055,8 @@ snapshots:
       extend-shallow: 3.0.2
       regex-not: 1.0.2
       safe-regex: 1.1.0
+
+  totalist@3.0.1: {}
 
   tough-cookie@4.1.4:
     dependencies:
@@ -12313,6 +12420,25 @@ snapshots:
 
   webidl-conversions@7.0.0: {}
 
+  webpack-bundle-analyzer@4.10.1:
+    dependencies:
+      '@discoveryjs/json-ext': 0.5.7
+      acorn: 8.15.0
+      acorn-walk: 8.3.5
+      commander: 7.2.0
+      debounce: 1.2.1
+      escape-string-regexp: 4.0.0
+      gzip-size: 6.0.0
+      html-escaper: 2.0.2
+      is-plain-object: 5.0.0
+      opener: 1.5.2
+      picocolors: 1.1.1
+      sirv: 2.0.4
+      ws: 7.5.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   webpack-dev-middleware@6.1.3(webpack@5.102.1(esbuild@0.25.11)):
     dependencies:
       colorette: 2.0.20
@@ -12453,6 +12579,8 @@ snapshots:
       strip-ansi: 7.1.2
 
   wrappy@1.0.2: {}
+
+  ws@7.5.10: {}
 
   ws@8.18.3: {}
 


### PR DESCRIPTION
## 📌 변경 사항 개요
이번 PR은 마이페이지(My Page) 신규 기능 구현과 함께 유저 경험(UX) 및 인증 관련 버그를 전면 수정한 작업입니다. 
- **마이페이지 레이아웃 및 탭 연동 (리뷰 내역, 찜 목록)**
- **Zustand 인증 상태(Tab/Refresh) 버그 해결 및 보완**
- **장소 상세 찜 기능 (Optimistic UI) 깜빡임 완벽 동기화**
- **API 에러 핸들링 및 접근성(ARIA) 개선**

## 📝 상세 내용
#### 1. 마이페이지 기능 구현 
- MyReviewHistory : 작성한 리뷰 내역 조회, 페이지네이션 및 리뷰 삭제 기능 연결
   - ⭐️ 별점 표기 시 스크린 리더 접근성(ARIA) 추가 개선 완료
   - 상세 리뷰 내역 확인을 위해 '장소 보기' 앵커로 연결
- MyWishlist : 찜한 장소 목록을 띄워주는 컴포넌트 추가
   - 기존의 `users/info` 대신 전용 API `/users/likes`로 통신 분리
   - 무한 로딩 방지 방어 코드 추가 (빈 목록 및 통신 실패 시 '다시 시도' UI 분기 처리)

#### 2. Zustand(Auth Store) 전역 탭 공유 및 하이드레이션 픽스
- 새 탭에서 로그인 정보가 풀리는 현상을 해결하기 위해 스토리지 방식을 `sessionStorage` → `localStorage`로 전환
- 새로고침 시 `isLoggedIn`과 `user` 상태가 불일치하는 하이드레이션(Hydration) 에러 수정 (user 객체 마스킹으로 PII 유출 방어)
- useLogoutMutation 훅 보완: 성공 시 로컬 스토리지에서 잔여 `accessToken` 완벽 제거

#### 3. 찜하기(Like) 기능 고도화 및 버그 픽스
- **Optimistic UI 오버라이딩 버그 해결**: 백그라운드 서버 데이터 재호출 시 발생하는 딜레이(`await Promise.all`)를 제어하여 빈 하트가 깜빡이는 현상(Blink) 수정
- 장소 상세 진입 시 내 찜 목록 서버 데이터(`useLikedPlaceIdsQuery` 와 교차 검증하도록 설계해 상태 100% 동기화
- 찜 추가/취소 명확한 인지를 위한 커스텀 토스트 알림 적용 (`success` vs `default`)
- 불필요/유효하지 않은 `Content-Type: false` 헤더 API 코드에서 완전히 제거
- 잘못된 접근(`NaN`) 시 백엔드 조회 차단 프론트엔드 가드 추가

## 🔗 관련 이슈
<!-- 관련된 이슈 번호 (예: Resolves: #123) -->
Resolves: #40 


## 🖼️ 스크린샷(선택사항)
<!-- UI 변경이 있는 경우 변경 전/후 스크린샷 -->
<img width="1218" height="947" alt="스크린샷 2026-03-10 오후 5 23 02" src="https://github.com/user-attachments/assets/57482636-a136-4a00-8e8e-652a5e61e2a4" />
<img width="1218" height="947" alt="스크린샷 2026-03-10 오후 5 23 18" src="https://github.com/user-attachments/assets/b5b3d0f7-97d0-4278-b710-791cbb0165d1" />
<img width="1218" height="947" alt="스크린샷 2026-03-10 오후 5 23 28" src="https://github.com/user-attachments/assets/e970f5fd-7dfc-496a-9f2e-dbd3cc957c02" />


## 💡 참고 사항
- 찜 목록을 가져오는 [useLikedPlacesQuery](cci:1://file:///Users/jihyun/source/sideproject/Together-Dog/apps/web/src/hooks/queries/useUserQuery.ts:104:0-137:2) 훅은 TypeScript 안정성을 높이기 위해 단순 `filter`가 아닌 **Type Guard (`is NonNullable`)** 를 적용해 무의미한 불필요한 호출 성능을 최적화시켰습니다.
- 리뷰 목록은 리뷰 기능 구현 후 추가 작업 예정입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 마이 페이지 확장: 프로필(아바타·가입일), 닉네임 수정, 비밀번호 변경, 리뷰 이력(삭제·페이지네이션), 위시리스트(썸네일·빈 상태 안내), 계정 설정(로그아웃·회원 탈퇴) 추가

* **버그 수정 / 개선**
  * 장소 좋아요(위시리스트) 즉시 반영 및 관련 데이터 자동 갱신
  * 인증 저장소를 sessionStorage→localStorage로 변경하고 일부 민감 정보 마스킹, 로그인/로그아웃 처리 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->